### PR TITLE
Vector NSStatusItem Icon

### DIFF
--- a/Slate.xcodeproj/project.pbxproj
+++ b/Slate.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		47C4A2D11384F3E10066B6DE /* Operation.m in Sources */ = {isa = PBXBuildFile; fileRef = 47C4A2D01384F3E10066B6DE /* Operation.m */; };
 		47C4A2D41384F4A60066B6DE /* MoveOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 47C4A2D31384F4A60066B6DE /* MoveOperation.m */; };
 		47C4A2D71384F5DE0066B6DE /* ExpressionPoint.m in Sources */ = {isa = PBXBuildFile; fileRef = 47C4A2D61384F5DE0066B6DE /* ExpressionPoint.m */; };
+		B3D087D0160577FB008A7FC6 /* statusTemplate.pdf in Resources */ = {isa = PBXBuildFile; fileRef = B3D087CF160577FB008A7FC6 /* statusTemplate.pdf */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -204,6 +205,7 @@
 		47C4A2D31384F4A60066B6DE /* MoveOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = MoveOperation.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		47C4A2D51384F5DD0066B6DE /* ExpressionPoint.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ExpressionPoint.h; sourceTree = "<group>"; };
 		47C4A2D61384F5DE0066B6DE /* ExpressionPoint.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ExpressionPoint.m; sourceTree = "<group>"; };
+		B3D087CF160577FB008A7FC6 /* statusTemplate.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = statusTemplate.pdf; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -258,6 +260,7 @@
 		4747E1F013877D260005180C /* icons */ = {
 			isa = PBXGroup;
 			children = (
+				B3D087CF160577FB008A7FC6 /* statusTemplate.pdf */,
 				47850890138BB234005DFB62 /* status.png */,
 				4747E1EE13877C150005180C /* icon.icns */,
 			);
@@ -537,6 +540,7 @@
 				47850891138BB234005DFB62 /* status.png in Resources */,
 				3B65CF251576CDF10063D298 /* ASCIIToCode_Dvorak.plist in Resources */,
 				3BBD24BA1580206C00940ABF /* default.slate in Resources */,
+				B3D087D0160577FB008A7FC6 /* statusTemplate.pdf in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Slate/SlateAppDelegate.m
+++ b/Slate/SlateAppDelegate.m
@@ -388,7 +388,7 @@ OSStatus OnModifiersChangedEvent(EventHandlerCallRef nextHandler, EventRef theEv
 
   statusItem = [[NSStatusBar systemStatusBar] statusItemWithLength: NSVariableStatusItemLength];
   [statusItem setMenu:statusMenu];
-  [statusItem setImage:[NSImage imageNamed:@"status"]];
+  [statusItem setImage:[NSImage imageNamed:@"statusTemplate"]];
   [statusItem setHighlightMode:YES];
 
   // Ensure no timer exists

--- a/statusTemplate.pdf
+++ b/statusTemplate.pdf
@@ -1,0 +1,617 @@
+%PDF-1.5%‚„œ”
+1 0 obj<</Metadata 2 0 R/Pages 3 0 R/Type/Catalog>>endobj2 0 obj<</Length 42802/Subtype/XML/Type/Metadata>>stream
+<?xpacket begin="Ôªø" id="W5M0MpCehiHzreSzNTczkc9d"?>
+<x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="Adobe XMP Core 5.3-c011 66.145661, 2012/02/06-14:56:27        ">
+   <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+      <rdf:Description rdf:about=""
+            xmlns:dc="http://purl.org/dc/elements/1.1/">
+         <dc:format>application/pdf</dc:format>
+         <dc:title>
+            <rdf:Alt>
+               <rdf:li xml:lang="x-default">slateTemplate</rdf:li>
+            </rdf:Alt>
+         </dc:title>
+      </rdf:Description>
+      <rdf:Description rdf:about=""
+            xmlns:xmp="http://ns.adobe.com/xap/1.0/"
+            xmlns:xmpGImg="http://ns.adobe.com/xap/1.0/g/img/">
+         <xmp:CreatorTool>Adobe Illustrator CS6 (Macintosh)</xmp:CreatorTool>
+         <xmp:CreateDate>2012-09-16T11:57:05+09:00</xmp:CreateDate>
+         <xmp:ModifyDate>2012-09-16T11:57:05+09:00</xmp:ModifyDate>
+         <xmp:MetadataDate>2012-09-16T11:57:05+09:00</xmp:MetadataDate>
+         <xmp:Thumbnails>
+            <rdf:Alt>
+               <rdf:li rdf:parseType="Resource">
+                  <xmpGImg:width>256</xmpGImg:width>
+                  <xmpGImg:height>256</xmpGImg:height>
+                  <xmpGImg:format>JPEG</xmpGImg:format>
+                  <xmpGImg:image>/9j/4AAQSkZJRgABAgEASABIAAD/7QAsUGhvdG9zaG9wIDMuMAA4QklNA+0AAAAAABAASAAAAAEA&#xA;AQBIAAAAAQAB/+4ADkFkb2JlAGTAAAAAAf/bAIQABgQEBAUEBgUFBgkGBQYJCwgGBggLDAoKCwoK&#xA;DBAMDAwMDAwQDA4PEA8ODBMTFBQTExwbGxscHx8fHx8fHx8fHwEHBwcNDA0YEBAYGhURFRofHx8f&#xA;Hx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8f/8AAEQgBAAEAAwER&#xA;AAIRAQMRAf/EAaIAAAAHAQEBAQEAAAAAAAAAAAQFAwIGAQAHCAkKCwEAAgIDAQEBAQEAAAAAAAAA&#xA;AQACAwQFBgcICQoLEAACAQMDAgQCBgcDBAIGAnMBAgMRBAAFIRIxQVEGE2EicYEUMpGhBxWxQiPB&#xA;UtHhMxZi8CRygvElQzRTkqKyY3PCNUQnk6OzNhdUZHTD0uIIJoMJChgZhJRFRqS0VtNVKBry4/PE&#xA;1OT0ZXWFlaW1xdXl9WZ2hpamtsbW5vY3R1dnd4eXp7fH1+f3OEhYaHiImKi4yNjo+Ck5SVlpeYmZ&#xA;qbnJ2en5KjpKWmp6ipqqusra6voRAAICAQIDBQUEBQYECAMDbQEAAhEDBCESMUEFURNhIgZxgZEy&#xA;obHwFMHR4SNCFVJicvEzJDRDghaSUyWiY7LCB3PSNeJEgxdUkwgJChgZJjZFGidkdFU38qOzwygp&#xA;0+PzhJSktMTU5PRldYWVpbXF1eX1RlZmdoaWprbG1ub2R1dnd4eXp7fH1+f3OEhYaHiImKi4yNjo&#xA;+DlJWWl5iZmpucnZ6fkqOkpaanqKmqq6ytrq+v/aAAwDAQACEQMRAD8A9U4q7FXYq7FXYq7FXYq7&#xA;FXYq7FXYq7FXYq7FXhn/ADkP/wA5DjyCB5d8uiO4803EYkllkAeOyjcfCzL+1K3VVOwG52oCq+Nv&#xA;Mfm/zT5luzd6/qt1qc5PIG5lZ1Wv8ik8UHsoAxV3lzzf5p8tXYu9A1W60ycHkTbSsitT+dQeLj2Y&#xA;EYq+yf8AnHj/AJyHHn4Hy75iEdv5pt4zJFLGAkd7Gg+JlX9mVerKNiNxtUBV7nirsVdirsVdirsV&#xA;dirsVdirsVdirsVdirsVdirsVdirsVdirsVdirsVdirsVdirsVdiriQBU7AdTir8w/N/mO78y+ad&#xA;V1+7JM+p3UtyQ2/FXYlU+SLRR7DFUnxV2Kpx5Q8x3flrzTpWv2hIn0y6iuQF25KjAsnydaqfY4q/&#xA;TzFXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq/KvFXYq7FXYq7FXYq7FX1L/AM43f843ev8A&#xA;VfOvnW1/c/DNo2jTL9vulxcIf2e6IevU7UBVfV+KuxV2KuIBFDuD1GKvyrxV2KuxV2Kv1UxV2Kux&#xA;VLfMflzRfMmi3Wi61apeabeJwngf7wykbqyndWG4O4xV8Ifnl+RWsflrqongMl95XvHpYakR8SN1&#xA;9C44gBZAOh6MNx3AVeWYq7FXYq7FXYq7FXYq/VTFXYq7FXYq/KvFXYq7FXYq7FXYq+pf+cbv+cbv&#xA;X+q+dfOtr+5+GbRtGmX7fdLi4Q/s90Q9ep2oCq+r8VdirsVdirsVflXirsVdirsVfqpirsVdirsV&#xA;QOuaHpGvaTc6RrFpHe6beIY7i2lFVZevzBB3BG4O43xV8K/nz+Q2qflzqhv7ASXnlK8kpZ3h3eBz&#xA;uIJyP2v5W6MPeoxV5HirsVdirsVdirsVfqpirsVdirsVflXirsVdirsVdir2j/nFjy5+Xmt+fuPm&#xA;qcPqFuFl0PS5lH1e5mWpYuxPxNHQFYyPi670pir7sxV2KuxV2KuxV2KvyrxV2KuxV2Kv1UxV2Kux&#xA;V2KuxVDanpmnarp9xp2pW8d3YXaGK5tplDI6NsQwOKvz3/PXyD5e8j+f7vRdB1JL6y4ib6tUtLZs&#xA;5J+ryv8AZYqNxvWhHLfqq88xV2KuxV2KuxV+qmKuxV2KuxV+VeKuxV2KuxV2KqkE81vNHPBI0U8T&#xA;B4pUJV1dTVWVhuCDuCMVfaf/ADjr/wA5FQ+b4YfK3mmZYvNMS8bS7aipfoo+4TgfaX9rqO4Cr33F&#xA;XYq7FXYq7FX5V4q7FXYq7FX6qYq7FXYq7FXYq8C/5yK/5yKh8oQzeVvK0yy+aZV43d2tGSwRh9xn&#xA;I+yv7PU9gVXxZPPNcTSTzyNLPKxeWVyWdnY1ZmY7kk7knFVPFXYq7FXYq7FX6qYq7FXYq7FX5V4q&#xA;7FXYq7FXYq7FVSCea3mjngkaKeJg8UqEq6upqrKw3BB3BGKvtP8A5x1/5yKh83ww+VvNMyxeaYl4&#xA;2l21FS/RR9wnA+0v7XUdwFXvuKuxV2KuxV+VeKuxV2KuxV+qmKuxV2KuxV4F/wA5Ff8AORUPlCGb&#xA;yt5WmWXzTKvG7u1oyWCMPuM5H2V/Z6nsCq+LJ55riaSeeRpZ5WLyyuSzs7GrMzHcknck4qp4q7FX&#xA;Yq7FXYq7FX6qYq7FXYq7FX5V4q7FXtHlz/nFjz9rf5eT+alpb6g4WbS9DlXjNc29CWcsSPTZtjGp&#xA;Hxd6VGKvG54JreaSCeNop4mKSxOCrq6mjKyncEHYg4qp4q7FXYqqQTzW80c8EjRTxMHilQlXV1NV&#xA;ZWG4IO4IxV9p/wDOOv8AzkVD5vhh8reaZli80xLxtLtqKl+ij7hOB9pf2uo7gKvfcVdirsVflXir&#xA;sVdirsVfqpirsVdirwL/AJyK/wCciofKEM3lbytMsvmmVeN3drRksEYfcZyPsr+z1PYFV8WTzzXE&#xA;0k88jSzysXllclnZ2NWZmO5JO5JxVTxV2KuxVUggmuJo4II2lnlYJFEgLOzsaKqqNySdgBir1Pzn&#xA;/wA43fmD5U8jWfmu8iWdWUvq2nwgtNYofsNIRUMKfbK/YPiN8VeUYq7FX6qYq7FXYq7FX5V4q+pf&#xA;+cbv+cbvX+q+dfOtr+5+GbRtGmX7fdLi4Q/s90Q9ep2oCq+r8VeBf85Ff846w+b4ZvNPlaFYvNMS&#xA;8ru0Wipfoo+4TgfZb9roexCr4sngmt5pIJ42iniYpLE4KurqaMrKdwQdiDiqnirsVdiqpBPNbzRz&#xA;wSNFPEweKVCVdXU1VlYbgg7gjFX2n/zjr/zkVD5vhh8reaZli80xLxtLtqKl+ij7hOB9pf2uo7gK&#xA;vfcVdir8q8VdirsVdir9VMVdirwL/nIr/nIqHyhDN5W8rTLL5plXjd3a0ZLBGH3Gcj7K/s9T2BVf&#xA;Fk881xNJPPI0s8rF5ZXJZ2djVmZjuSTuScVU8VdirsVVIIJriaOCCNpZ5WCRRICzs7GiqqjcknYA&#xA;Yq+0/wDnHX/nHWHyhDD5p80wrL5plXlaWjUZLBGH3Gcj7Tfs9B3JVe9yRxyxtHIoeNwVdGAKspFC&#xA;CD1BxV8f/wDORv8AzjdJoklx5w8l2pfRXJk1TSYVJNoTu0sKj/dH8yj7H+r9lV824q/VTFXYq7FX&#xA;Yq+UP+cbv+cbvX+q+dfOtr+5+GbRtGmX7fdLi4Q/s90Q9ep2oCq+r8VdirsVeBf85Ff846w+b4Zv&#xA;NPlaFYvNMS8ru0Wipfoo+4TgfZb9roexCr4sngmt5pIJ42iniYpLE4KurqaMrKdwQdiDiqnirsVd&#xA;iqpBPNbzRzwSNFPEweKVCVdXU1VlYbgg7gjFX6oYq7FX5V4q7FXYq7FX6qYq7FX5XzzzXE0k88jS&#xA;zysXllclnZ2NWZmO5JO5JxVTxV2KuxVUggmuJo4II2lnlYJFEgLOzsaKqqNySdgBir7T/wCcdf8A&#xA;nHWHyhDD5p80wrL5plXlaWjUZLBGH3Gcj7Tfs9B3JVe+4q7FXEAih3B6jFXyT/zkX/zjTJZPdecf&#xA;JFrysKNNq2ixDeE9WmtkHWPuyD7PUfDsqr62xV2KuxV2KuxV2KuxV2KuxV4F/wA5Ff8AOOsPm+Gb&#xA;zT5WhWLzTEvK7tFoqX6KPuE4H2W/a6HsQq+LJ4JreaSCeNop4mKSxOCrq6mjKyncEHYg4qp4q7FX&#xA;Yq/VTFXYq/KvFXYq7FXYq/VTFXYq/KvFXYq7FVSCCa4mjggjaWeVgkUSAs7Oxoqqo3JJ2AGKvtP/&#xA;AJx1/wCcdYfKEMPmnzTCsvmmVeVpaNRksEYfcZyPtN+z0HclV77irsVdirsVdirsVdirsVdirsVd&#xA;irsVdirsVdirwL/nIr/nHWHzfDN5p8rQrF5piXld2i0VL9FH3CcD7LftdD2IVfFk8E1vNJBPG0U8&#xA;TFJYnBV1dTRlZTuCDsQcVU8Vdir9VMVdir8q8VdirsVdir9VMVdir8q8VdiqpBBNcTRwQRtLPKwS&#xA;KJAWdnY0VVUbkk7ADFX2n/zjr/zjrD5Qhh80+aYVl80yrytLRqMlgjD7jOR9pv2eg7kqvfcVdirs&#xA;VdirsVdirsVdirsVdirsVdirsVdirsVdirsVdirsVdirsVdir8q8VdirsVdir9VMVdirsVdirsVd&#xA;irsVdirsVdirsVdirsVdirsVdirsVdirsVdirsVdirsVdirsVdirsVdir8q8VdirsVdir9VMVdir&#xA;sVdirsVdirsVdirsVdirsVdirsVdirwz/nIf/nIceQQPLvl0R3Hmm4jEkssgDx2Ubj4WZf2pW6qp&#xA;2A3O1AVXxt5j83+afMt2bvX9VutTnJ5A3MrOq1/kUnig9lAGKpPirsVdirsVdirsVdirsVdirsVd&#xA;irsVfqV+idK/5YoP+RSf0xV36J0r/lig/wCRSf0xV36J0r/lig/5FJ/TFXfonSv+WKD/AJFJ/TFX&#xA;5a4q7FXYq7FXYq7FXYq7FXYq7FXYq7FU48ueb/NPlq7F3oGq3WmTg8ibaVkVqfzqDxcezAjFX2T/&#xA;AM48f85Djz8D5d8xCO38028ZkiljASO9jQfEyr+zKvVlGxG42qAq+NvN/mO78y+adV1+7JM+p3Ut&#xA;yQ2/FXYlU+SLRR7DFUnxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV+qmKuxV2KuxV+VeKuxV2KuxV2&#xA;KuxV2KuxV2KuxV2KuxV2Kpx5Q8x3flrzTpWv2hIn0y6iuQF25KjAsnydaqfY4q7zf5cu/LXmnVdA&#xA;uwRPpl1LbEttyVGIV/k60YexxVJ8VdirsVdirsVdirsVdirsVdirsVdirsVfqpirsVdirsVflXir&#xA;sVdirsVdirsVdirsVdirsVdirsVdiqceUPLl35l806VoFoCZ9TuorYFd+KuwDP8AJFqx9hir7J/5&#xA;yH/5x4Hn4DzF5dMdv5pt4xHLFIQkd7Gg+FWb9mVeisdiNjtQhV8beY/KHmny1dm01/SrrTJweIFz&#xA;EyK1P5GI4uPdSRiqT4q7FXYq7FXYq7FXYq7FXYq7FXYq7FX6qYq7FXYq7FX5V4q7FXYq7FXYq7FX&#xA;Yq7FXYq7FXYq7FU48ueUPNPmW7FpoGlXWpzk8SLaJnVa/wA7AcUHuxAxV9k/848f848DyCD5i8xG&#xA;O4803EZjiijIeOyjcfEqt+1K3RmGwGw2qSq9zxV2KoX9E6V/yxQf8ik/pirv0TpX/LFB/wAik/pi&#xA;rv0TpX/LFB/yKT+mKu/ROlf8sUH/ACKT+mKu/ROlf8sUH/IpP6Yq79E6V/yxQf8AIpP6Yq79E6V/&#xA;yxQf8ik/pirv0TpX/LFB/wAik/pirv0TpX/LFB/yKT+mKu/ROlf8sUH/ACKT+mKu/ROlf8sUH/Ip&#xA;P6Yq79E6V/yxQf8AIpP6Yq/LXFXYq7FXYq/Ur9E6V/yxQf8AIpP6Yq79E6V/yxQf8ik/pirv0TpX&#xA;/LFB/wAik/pirv0TpX/LFB/yKT+mKu/ROlf8sUH/ACKT+mKu/ROlf8sUH/IpP6Yq79E6V/yxQf8A&#xA;IpP6Yq79E6V/yxQf8ik/pirv0TpX/LFB/wAik/pirv0TpX/LFB/yKT+mKu/ROlf8sUH/ACKT+mKu&#xA;/ROlf8sUH/IpP6YqisVdirsVdirsVdirsVdirsVdirsVdirsVdirsVdir8q8VdirsVdir9VMVdir&#xA;sVdirsVdirsVdirsVdirsVdirsVdirsVdirsVdirsVdirsVdirwL/nIr/nIqHyhDN5W8rTLL5plX&#xA;jd3a0ZLBGH3Gcj7K/s9T2BVfFk881xNJPPI0s8rF5ZXJZ2djVmZjuSTuScVU8Vdir9VMVdir8q8V&#xA;dirsVdir9VMVdir8q8VdiqpBPNbzRzwSNFPEweKVCVdXU1VlYbgg7gjFX2n/AM46/wDORUPm+GHy&#xA;t5pmWLzTEvG0u2oqX6KPuE4H2l/a6juAq99xV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV4F/z&#xA;kV/zkVD5Qhm8reVpll80yrxu7taMlgjD7jOR9lf2ep7Aqviyeea4mknnkaWeVi8srks7OxqzMx3J&#xA;J3JOKqeKuxV2Kv1UxV2KvyrxV2KuxV2Kv1UxV2KvyrxV2KuxVUgnmt5o54JGiniYPFKhKurqaqys&#xA;NwQdwRir7T/5x1/5yKh83ww+VvNMyxeaYl42l21FS/RR9wnA+0v7XUdwFXvuKuxV2KuxV2KuxV2K&#xA;uxV2KvlD/nG7/nJH0Pqvkrzrdfufhh0bWZm+x2S3uHP7PZHPTodqEKvq/FXYq7FXgX/ORX/ORUPl&#xA;CGbyt5WmWXzTKvG7u1oyWCMPuM5H2V/Z6nsCq+LJ55riaSeeRpZ5WLyyuSzs7GrMzHcknck4qp4q&#xA;7FXYqqQQTXE0cEEbSzysEiiQFnZ2NFVVG5JOwAxV+qGKuxV+VeKuxV2KuxV+qmKuxV+V88E1vNJB&#xA;PG0U8TFJYnBV1dTRlZTuCDsQcVU8VdirsVVIJ5reaOeCRop4mDxSoSrq6mqsrDcEHcEYq+0/+cdf&#xA;+ciofN8MPlbzTMsXmmJeNpdtRUv0UfcJwPtL+11HcBV77irsVaZlVSzEKqirMdgAO5xV8i/85Hf8&#xA;5JjVVuPJ3km6/wBxZBj1bWYTT6xXZoIGH+6uzv8At9B8P2lX13irsVdirsVflXir6l/5xu/5yR9D&#xA;6r5K863X7n4YdG1mZvsdkt7hz+z2Rz06HahCr6vxV4F/zkV/zkVD5Qhm8reVpll80yrxu7taMlgj&#xA;D7jOR9lf2ep7Aqviyeea4mknnkaWeVi8srks7OxqzMx3JJ3JOKqeKuxV2KqkEE1xNHBBG0s8rBIo&#xA;kBZ2djRVVRuSTsAMVfaf/OOv/OOsPlCGHzT5phWXzTKvK0tGoyWCMPuM5H2m/Z6DuSq99xV2Kvyr&#xA;xV2KuxV2Kv1UxV2KvAv+civ+cdYfN8M3mnytCsXmmJeV3aLRUv0UfcJwPst+10PYhV8WTwTW80kE&#xA;8bRTxMUlicFXV1NGVlO4IOxBxVTxV2KuxVUgnmt5o54JGiniYPFKhKurqaqysNwQdwRir7T/AOcd&#xA;f+ciofN8MPlbzTMsXmmJeNpdtRUv0UfcJwPtL+11HcBV73JJHFG0kjBI0BZ3YgKqgVJJPQDFXx3/&#xA;AM5Ff85JnzCtx5R8mXDJodWj1TVEPFruhoYoiNxB4t+3/q/aVfOOKv1UxV2KuxV2KvyrxV2KvaPL&#xA;n/OU/n7RPy8n8qrS41BAsOl65K3Ka2t6EMhUg+oy7CNifh71oMVeNzzzXE0k88jSzysXllclnZ2N&#xA;WZmO5JO5JxVTxV2KuxVUggmuJo4II2lnlYJFEgLOzsaKqqNySdgBir7T/wCcdf8AnHWHyhDD5p80&#xA;wrL5plXlaWjUZLBGH3Gcj7Tfs9B3JVe+4q7FXYq/KvFXYq7FXYq/VTFXYq7FXgX/ADkV/wA46w+b&#xA;4ZvNPlaFYvNMS8ru0Wipfoo+4TgfZb9roexCr4sngmt5pIJ42iniYpLE4KurqaMrKdwQdiDiqnir&#xA;sVdiqpBPNbzRzwSNFPEweKVCVdXU1VlYbgg7gjFXqfnP/nJH8wfNfkaz8qXkqwKqlNW1CElZr5B9&#xA;hZAKBRT7YX7Z8BtiryjFXYq/VTFXYq7FXYq/KvFXYq7FXYq7FXYqqQQTXE0cEEbSzysEiiQFnZ2N&#xA;FVVG5JOwAxV9p/8AOOv/ADjrD5Qhh80+aYVl80yrytLRqMlgjD7jOR9pv2eg7kqvfcVdirsVdir8&#xA;q8VdirsVdir9VMVdirsVdirwL/nIr/nHWHzfDN5p8rQrF5piXld2i0VL9FH3CcD7LftdD2IVfFk8&#xA;E1vNJBPG0U8TFJYnBV1dTRlZTuCDsQcVU8VdirsVdirsVdir9VMVdirsVdir8q8VdirsVdirsVVI&#xA;IJriaOCCNpZ5WCRRICzs7GiqqjcknYAYq+0/+cdf+cdYfKEMPmnzTCsvmmVeVpaNRksEYfcZyPtN&#xA;+z0HclV77irsVdirsVdir8q8VdirsVdir9VMVdirsVdirsVeBf8AORX/ADjrD5vhm80+VoVi80xL&#xA;yu7RaKl+ij7hOB9lv2uh7EKviyeCa3mkgnjaKeJiksTgq6upoysp3BB2IOKqeKuxV2KuxV2Kv1Ux&#xA;V2KuxV2KvyrxV2KuxV2KuxV7R/zix5j/AC80Tz9y81QBNQuAsWh6pMw+r20zVDB1I+FpKgLIT8PT&#xA;atcVfdmKuxV2KuxV2KuxV+VeKuxV2KuxV+qmKuxV2KuxV2KoXVdW0zSNOuNS1O6jsrC1QyXF1MwS&#xA;NFHcscVfnx+evn7y9548/wB3rWg6aljZcRD9ZoVlvGQkfWJU+ypYbDatAOW/RV55irsVdirsVdir&#xA;9VMVdirsVdir8q8VdirsVdirsVdir6l/5xu/5yR9D6r5K863X7n4YdG1mZvsdkt7hz+z2Rz06Hah&#xA;Cr6vxV2KuxV2KuxV+VeKuxV2KuxV+qmKuxV2KuxVAa7rukaBpF1rGsXSWWm2SGS4uJDRVUfiSTsA&#xA;Nydhvir4W/Pn8+dU/MbVDYWBks/KVnJWzszs87jYTzgftfyr0Ue9TiryPFXYq7FXYq7FXYq/VTFX&#xA;Yq7FXYq/KvFXYq7FXYq7FXYq7FX1L/zjd/zkj6H1XyV51uv3Pww6NrMzfY7Jb3Dn9nsjnp0O1CFX&#xA;1firsVdirsVflXirsVdirsVfqpirsVdiqW+Y/Mei+W9Futa1q6Sz02zTnPO/3BVA3ZmOyqNydhir&#xA;4Q/PH89dZ/MrVBBCHsPK9m1bDTSfidunr3HHZpD2HRRsO5KryzFXYq7FXYq7FXYq7FX6qYq7FXYq&#xA;7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FX5h+b/Ll35a806roF2CJ9MupbYltuSoxCv8AJ1ow9jiq&#xA;T4q7FU48oeXLvzL5p0rQLQEz6ndRWwK78VdgGf5ItWPsMVfp5irsVdirsVdirsVdirsVdirsVdir&#xA;sVdirsVdirsVdirsVdirsVdirsVdirsVdirsVdirsVeGf85D/wDOPA8/AeYvLpjt/NNvGI5YpCEj&#xA;vY0Hwqzfsyr0VjsRsdqEKvjbzH5Q80+Wrs2mv6VdaZODxAuYmRWp/IxHFx7qSMVd5c8oeafMt2LT&#xA;QNKutTnJ4kW0TOq1/nYDig92IGKvsn/nHj/nHgeQQfMXmIx3Hmm4jMcUUZDx2Ubj4lVv2pW6Mw2A&#xA;2G1SVXueKuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV//2Q==</xmpGImg:image>
+               </rdf:li>
+            </rdf:Alt>
+         </xmp:Thumbnails>
+      </rdf:Description>
+      <rdf:Description rdf:about=""
+            xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"
+            xmlns:stRef="http://ns.adobe.com/xap/1.0/sType/ResourceRef#"
+            xmlns:stEvt="http://ns.adobe.com/xap/1.0/sType/ResourceEvent#">
+         <xmpMM:RenditionClass>proof:pdf</xmpMM:RenditionClass>
+         <xmpMM:OriginalDocumentID>uuid:65E6390686CF11DBA6E2D887CEACB407</xmpMM:OriginalDocumentID>
+         <xmpMM:DocumentID>xmp.did:01801174072068118083F2439C300120</xmpMM:DocumentID>
+         <xmpMM:InstanceID>uuid:7bc7d74f-f191-6d41-ab19-979713637866</xmpMM:InstanceID>
+         <xmpMM:DerivedFrom rdf:parseType="Resource">
+            <stRef:instanceID>uuid:0422f9ea-96fe-9946-a099-8d9eefc40c79</stRef:instanceID>
+            <stRef:documentID>xmp.did:66A6819719206811822A897E387FE54C</stRef:documentID>
+            <stRef:originalDocumentID>uuid:65E6390686CF11DBA6E2D887CEACB407</stRef:originalDocumentID>
+            <stRef:renditionClass>proof:pdf</stRef:renditionClass>
+         </xmpMM:DerivedFrom>
+         <xmpMM:History>
+            <rdf:Seq>
+               <rdf:li rdf:parseType="Resource">
+                  <stEvt:action>saved</stEvt:action>
+                  <stEvt:instanceID>xmp.iid:01801174072068118083F2439C300120</stEvt:instanceID>
+                  <stEvt:when>2012-09-16T11:56:54+09:00</stEvt:when>
+                  <stEvt:softwareAgent>Adobe Illustrator CS6 (Macintosh)</stEvt:softwareAgent>
+                  <stEvt:changed>/</stEvt:changed>
+               </rdf:li>
+            </rdf:Seq>
+         </xmpMM:History>
+      </rdf:Description>
+      <rdf:Description rdf:about=""
+            xmlns:illustrator="http://ns.adobe.com/illustrator/1.0/">
+         <illustrator:StartupProfile>Web</illustrator:StartupProfile>
+      </rdf:Description>
+      <rdf:Description rdf:about=""
+            xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"
+            xmlns:stDim="http://ns.adobe.com/xap/1.0/sType/Dimensions#"
+            xmlns:xmpG="http://ns.adobe.com/xap/1.0/g/">
+         <xmpTPg:NPages>1</xmpTPg:NPages>
+         <xmpTPg:HasVisibleTransparency>False</xmpTPg:HasVisibleTransparency>
+         <xmpTPg:HasVisibleOverprint>False</xmpTPg:HasVisibleOverprint>
+         <xmpTPg:MaxPageSize rdf:parseType="Resource">
+            <stDim:w>16.000000</stDim:w>
+            <stDim:h>16.000000</stDim:h>
+            <stDim:unit>Pixels</stDim:unit>
+         </xmpTPg:MaxPageSize>
+         <xmpTPg:PlateNames>
+            <rdf:Seq>
+               <rdf:li>Cyan</rdf:li>
+               <rdf:li>Magenta</rdf:li>
+               <rdf:li>Yellow</rdf:li>
+               <rdf:li>Black</rdf:li>
+            </rdf:Seq>
+         </xmpTPg:PlateNames>
+         <xmpTPg:SwatchGroups>
+            <rdf:Seq>
+               <rdf:li rdf:parseType="Resource">
+                  <xmpG:groupName>Default Swatch Group</xmpG:groupName>
+                  <xmpG:groupType>0</xmpG:groupType>
+                  <xmpG:Colorants>
+                     <rdf:Seq>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>White</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>255</xmpG:red>
+                           <xmpG:green>255</xmpG:green>
+                           <xmpG:blue>255</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>Black</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>0</xmpG:red>
+                           <xmpG:green>0</xmpG:green>
+                           <xmpG:blue>0</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>RGB Red</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>255</xmpG:red>
+                           <xmpG:green>0</xmpG:green>
+                           <xmpG:blue>0</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>RGB Yellow</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>255</xmpG:red>
+                           <xmpG:green>255</xmpG:green>
+                           <xmpG:blue>0</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>RGB Green</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>0</xmpG:red>
+                           <xmpG:green>255</xmpG:green>
+                           <xmpG:blue>0</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>RGB Cyan</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>0</xmpG:red>
+                           <xmpG:green>255</xmpG:green>
+                           <xmpG:blue>255</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>RGB Blue</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>0</xmpG:red>
+                           <xmpG:green>0</xmpG:green>
+                           <xmpG:blue>255</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>RGB Magenta</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>255</xmpG:red>
+                           <xmpG:green>0</xmpG:green>
+                           <xmpG:blue>255</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=193 G=39 B=45</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>193</xmpG:red>
+                           <xmpG:green>39</xmpG:green>
+                           <xmpG:blue>45</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=237 G=28 B=36</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>237</xmpG:red>
+                           <xmpG:green>28</xmpG:green>
+                           <xmpG:blue>36</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=241 G=90 B=36</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>241</xmpG:red>
+                           <xmpG:green>90</xmpG:green>
+                           <xmpG:blue>36</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=247 G=147 B=30</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>247</xmpG:red>
+                           <xmpG:green>147</xmpG:green>
+                           <xmpG:blue>30</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=251 G=176 B=59</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>251</xmpG:red>
+                           <xmpG:green>176</xmpG:green>
+                           <xmpG:blue>59</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=252 G=238 B=33</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>252</xmpG:red>
+                           <xmpG:green>238</xmpG:green>
+                           <xmpG:blue>33</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=217 G=224 B=33</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>217</xmpG:red>
+                           <xmpG:green>224</xmpG:green>
+                           <xmpG:blue>33</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=140 G=198 B=63</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>140</xmpG:red>
+                           <xmpG:green>198</xmpG:green>
+                           <xmpG:blue>63</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=57 G=181 B=74</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>57</xmpG:red>
+                           <xmpG:green>181</xmpG:green>
+                           <xmpG:blue>74</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=0 G=146 B=69</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>0</xmpG:red>
+                           <xmpG:green>146</xmpG:green>
+                           <xmpG:blue>69</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=0 G=104 B=55</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>0</xmpG:red>
+                           <xmpG:green>104</xmpG:green>
+                           <xmpG:blue>55</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=34 G=181 B=115</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>34</xmpG:red>
+                           <xmpG:green>181</xmpG:green>
+                           <xmpG:blue>115</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=0 G=169 B=157</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>0</xmpG:red>
+                           <xmpG:green>169</xmpG:green>
+                           <xmpG:blue>157</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=41 G=171 B=226</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>41</xmpG:red>
+                           <xmpG:green>171</xmpG:green>
+                           <xmpG:blue>226</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=0 G=113 B=188</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>0</xmpG:red>
+                           <xmpG:green>113</xmpG:green>
+                           <xmpG:blue>188</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=46 G=49 B=146</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>46</xmpG:red>
+                           <xmpG:green>49</xmpG:green>
+                           <xmpG:blue>146</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=27 G=20 B=100</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>27</xmpG:red>
+                           <xmpG:green>20</xmpG:green>
+                           <xmpG:blue>100</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=102 G=45 B=145</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>102</xmpG:red>
+                           <xmpG:green>45</xmpG:green>
+                           <xmpG:blue>145</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=147 G=39 B=143</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>147</xmpG:red>
+                           <xmpG:green>39</xmpG:green>
+                           <xmpG:blue>143</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=158 G=0 B=93</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>158</xmpG:red>
+                           <xmpG:green>0</xmpG:green>
+                           <xmpG:blue>93</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=212 G=20 B=90</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>212</xmpG:red>
+                           <xmpG:green>20</xmpG:green>
+                           <xmpG:blue>90</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=237 G=30 B=121</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>237</xmpG:red>
+                           <xmpG:green>30</xmpG:green>
+                           <xmpG:blue>121</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=199 G=178 B=153</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>199</xmpG:red>
+                           <xmpG:green>178</xmpG:green>
+                           <xmpG:blue>153</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=153 G=134 B=117</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>153</xmpG:red>
+                           <xmpG:green>134</xmpG:green>
+                           <xmpG:blue>117</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=115 G=99 B=87</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>115</xmpG:red>
+                           <xmpG:green>99</xmpG:green>
+                           <xmpG:blue>87</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=83 G=71 B=65</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>83</xmpG:red>
+                           <xmpG:green>71</xmpG:green>
+                           <xmpG:blue>65</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=198 G=156 B=109</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>198</xmpG:red>
+                           <xmpG:green>156</xmpG:green>
+                           <xmpG:blue>109</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=166 G=124 B=82</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>166</xmpG:red>
+                           <xmpG:green>124</xmpG:green>
+                           <xmpG:blue>82</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=140 G=98 B=57</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>140</xmpG:red>
+                           <xmpG:green>98</xmpG:green>
+                           <xmpG:blue>57</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=117 G=76 B=36</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>117</xmpG:red>
+                           <xmpG:green>76</xmpG:green>
+                           <xmpG:blue>36</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=96 G=56 B=19</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>96</xmpG:red>
+                           <xmpG:green>56</xmpG:green>
+                           <xmpG:blue>19</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=66 G=33 B=11</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>66</xmpG:red>
+                           <xmpG:green>33</xmpG:green>
+                           <xmpG:blue>11</xmpG:blue>
+                        </rdf:li>
+                     </rdf:Seq>
+                  </xmpG:Colorants>
+               </rdf:li>
+               <rdf:li rdf:parseType="Resource">
+                  <xmpG:groupName>Grays</xmpG:groupName>
+                  <xmpG:groupType>1</xmpG:groupType>
+                  <xmpG:Colorants>
+                     <rdf:Seq>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=0 G=0 B=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>0</xmpG:red>
+                           <xmpG:green>0</xmpG:green>
+                           <xmpG:blue>0</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=26 G=26 B=26</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>26</xmpG:red>
+                           <xmpG:green>26</xmpG:green>
+                           <xmpG:blue>26</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=51 G=51 B=51</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>51</xmpG:red>
+                           <xmpG:green>51</xmpG:green>
+                           <xmpG:blue>51</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=77 G=77 B=77</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>77</xmpG:red>
+                           <xmpG:green>77</xmpG:green>
+                           <xmpG:blue>77</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=102 G=102 B=102</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>102</xmpG:red>
+                           <xmpG:green>102</xmpG:green>
+                           <xmpG:blue>102</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=128 G=128 B=128</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>128</xmpG:red>
+                           <xmpG:green>128</xmpG:green>
+                           <xmpG:blue>128</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=153 G=153 B=153</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>153</xmpG:red>
+                           <xmpG:green>153</xmpG:green>
+                           <xmpG:blue>153</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=179 G=179 B=179</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>179</xmpG:red>
+                           <xmpG:green>179</xmpG:green>
+                           <xmpG:blue>179</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=204 G=204 B=204</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>204</xmpG:red>
+                           <xmpG:green>204</xmpG:green>
+                           <xmpG:blue>204</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=230 G=230 B=230</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>230</xmpG:red>
+                           <xmpG:green>230</xmpG:green>
+                           <xmpG:blue>230</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=242 G=242 B=242</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>242</xmpG:red>
+                           <xmpG:green>242</xmpG:green>
+                           <xmpG:blue>242</xmpG:blue>
+                        </rdf:li>
+                     </rdf:Seq>
+                  </xmpG:Colorants>
+               </rdf:li>
+               <rdf:li rdf:parseType="Resource">
+                  <xmpG:groupName>Web Color Group</xmpG:groupName>
+                  <xmpG:groupType>1</xmpG:groupType>
+                  <xmpG:Colorants>
+                     <rdf:Seq>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=63 G=169 B=245</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>63</xmpG:red>
+                           <xmpG:green>169</xmpG:green>
+                           <xmpG:blue>245</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=122 G=201 B=67</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>122</xmpG:red>
+                           <xmpG:green>201</xmpG:green>
+                           <xmpG:blue>67</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=255 G=147 B=30</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>255</xmpG:red>
+                           <xmpG:green>147</xmpG:green>
+                           <xmpG:blue>30</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=255 G=29 B=37</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>255</xmpG:red>
+                           <xmpG:green>29</xmpG:green>
+                           <xmpG:blue>37</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=255 G=123 B=172</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>255</xmpG:red>
+                           <xmpG:green>123</xmpG:green>
+                           <xmpG:blue>172</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=189 G=204 B=212</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>189</xmpG:red>
+                           <xmpG:green>204</xmpG:green>
+                           <xmpG:blue>212</xmpG:blue>
+                        </rdf:li>
+                     </rdf:Seq>
+                  </xmpG:Colorants>
+               </rdf:li>
+            </rdf:Seq>
+         </xmpTPg:SwatchGroups>
+      </rdf:Description>
+      <rdf:Description rdf:about=""
+            xmlns:pdf="http://ns.adobe.com/pdf/1.3/">
+         <pdf:Producer>Adobe PDF library 10.01</pdf:Producer>
+      </rdf:Description>
+   </rdf:RDF>
+</x:xmpmeta>
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                           
+<?xpacket end="w"?>endstreamendobj3 0 obj<</Count 1/Kids[5 0 R]/Type/Pages>>endobj5 0 obj<</ArtBox[0.0 0.0 16.0 16.0]/BleedBox[0.0 0.0 16.0 16.0]/Contents 6 0 R/MediaBox[0.0 0.0 16.0 16.0]/Parent 3 0 R/Resources<</ColorSpace<</CS0 7 0 R>>/ExtGState<</GS0 8 0 R>>/Properties<</MC0 9 0 R>>>>/TrimBox[0.0 0.0 16.0 16.0]/Type/Page>>endobj6 0 obj<</Filter/FlateDecode/Length 336>>stream
+Hâ|ì±n√ Üwû‚^‡0ÿ@`ç[uiÜ®CÁ J€!â‘xÍ€˜é√ƒ§iÂ0¸ˇwøé§{~˚>\†€ç∂#®n|10Õ`ÚÛtV›m}ÃÍlﬁ¥`çéﬁ∞¶ì‚Ωìr⁄∫8ËîÀ´°’ßzW˚µŸ”PmXçˇ»õ*fU·ÆºÅ£+ÙµîŒ8z §ÔÂ†^·ºÚß6úe?O⁄˚–hG1)J,Ö6N_Uº‚≥>ó≈ÏÛ~Ä"&Ø|H"@‰ÍEƒï' p˛HbˆQ‚A	6lßIê¢†ÉH€#˘BFíäjìMõ¬ê”êüÈ∂ÈV;Î¯¢ØÕË5ôÚpTVõ`–1yŒó’ c}Ωw;‘†Ë¨WîâX∏(`\»B¬Ö¸78‘»7‰,D¡◊àlÆÀ_ø?≥§n;±D0.‰∂ZÏ„é˛b{ı#¿ #Ñ™Üendstreamendobj9 0 obj<</Color[20224 32768 65535]/Dimmed false/Editable true/Preview true/Printed true/Title(Layer 1)/Visible true>>endobj8 0 obj<</AIS false/BM/Normal/CA 1.0/OP false/OPM 1/SA true/SMask/None/Type/ExtGState/ca 1.0/op false>>endobj7 0 obj[/ICCBased 10 0 R]endobj10 0 obj<</Filter/FlateDecode/Length 2574/N 3>>stream
+HâúñyTSw«o…ûêï∞√c[Ä∞ê5laëQIBHÿADEDÑ™ï2÷mtFOEù.Æc≠÷}Í“ı0ÍË8¥◊éù8GùNg¶”ÔÔ˜9˜wÔÔ›ﬂΩ˜ùÛ †'•™µ’0 ç÷†œJå≈b§	 
+  2y≠.-;!‡í∆K∞Z‹	¸ãû^êiΩ"L ¿0ˇâ-◊È @8(îµrú;qÆ™7ËLˆúy•ï&ÜQÎÒq∂4±jûΩÁ|Ê9⁄ƒ
+çVÅ≥)gùB£0ÒiúW◊ï8#©8w’©ïı8_≈Ÿ• ®Q„¸‹´Q j@È&ªA)/«Ÿg∫>'KÇÛ »t’;\˙î”•$’∫FΩZUn¿‹Âò(4Tå%)Î´îÉ0C&ØîÈò§Z£ìiòøÛú8¶⁄bxëÉE°¡¡B—;Ö˙ØõøP¶ﬁŒ”ìÃπûA¸om?ÁW=
+ÄxØÕ˙∑∂“- åØ¿ÚÊ[õÀ˚ 0Òææ¯Œ}¯¶y)7taææııı>j•‹«T–7˙üø@Ôºœ«t‹õÚ`q 2ô± ÄôÍ&ØÆ™6Í±ZùLÆƒÑ?‚_¯Ûyxg)Àîz•è»√ßL≠U·Ì÷*‘uµSkˇSeÿO4?◊∏∏cØØÿ∞.Ú Ú∑ Â“ R¥ﬂÅﬁÙ-ïí25ﬂ·ﬁ¸‹œ	˙˜S·>”£V≠öãìdÂ`r£æn~œÙY†&‡+`úÅ;¬A4à… ‰Ä∞»A9– =®-†tÅ∞l√`;ª¡~påÉè¡	Gp|	ÆÅ[`LÉá`<Ø "AàYAê+‰˘Cb(äáR°,® *ÅTê2B-–
+®ÍáÜ°–nË˜–QËt∫}MA†Ô†ó0”alª¡æ∞éÅS‡x	¨Çk‡&∏^¡£>¯0|>_É'·á,¬G!"F$H:Ràî!z§ÈFëQd?r9ã\A&ëG»îàrQ¢·höã —¥ÌEá—]ËaÙ4zùBg–◊¡ñ‡E#H	ã*B=°ã0HÿI¯àpÜpç0MxJ$˘D1ÑòD, VõâΩƒ≠ƒƒ„ƒKƒªƒYâdEÚ"Eê“I2íÅ‘E⁄B⁄G˙åtô4MzN¶ë»˛‰r!YKÓ í˜ê?%_&ﬂ#ø¢∞(Æî0J:EAi§ÙQ∆(«()”îWT6U@ç†ÊP+®Ì‘!Í~ÍÍmÍçÊD•e“‘¥Â¥!⁄Ôhü”¶h/Ë∫']B/¢ÈÎË“è”ø¢?a0nåhF!√¿X«ÿÕ8≈¯öÒ‹åkÊc&5Sòµôçò6ªlˆòIa∫2còKôMÃAÊ!ÊEÊ#ÖÂ∆í∞d¨V÷Î(ÎkñÕeãÿÈlªóΩá}é}üC‚∏q‚9
+N'ÁŒ)Œ].¬uÊJ∏rÓ
+Ó˜wöG‰	xR^Øá˜[ﬁo∆úchûgﬁ`>b˛â˘$·ªÒ•¸*~ˇ ˇ:ˇ•ÖùEåÖ“bç≈~ãÀœ,m,£-ïñ›ñ,ØYæ¥¬¨‚≠*≠6Xç[›±F≠=≠3≠Î≠∑Yü±~d√≥	∑ë€t€¥πi€z⁄fŸ6€~`{¡v÷Œﬁ.—Ng∑≈Óî›#{æ}¥}Ö˝Ä˝ßˆ∏ëjááœ˛äôc1X6Ñù∆fmìçé;'_9	úrù:ú8›q¶:ãùÀúúO:œ∏8∏§π¥∏ÏuπÈJqªñªnv=Î˙ÃM‡ñÔ∂ m‹Ìæ¿R 4	ˆ
+nª3‹£‹k‹G›Øz=ƒï[=æÙÑ=É<À=G</z¡^¡^jØ≠^óº	ﬁ°ﬁZÔQÔB∫0FX'‹+úÚ·˚§˙t¯å˚<ˆuÒ-Ù›‡{÷˜µ_ê_ïﬂòﬂ-Gî,Í}ÁÔÈ/˜Òø¿Hh8m†W†2p[‡üÉ∏AiA´ÇN˝#8$Xº?¯AàKHI»{!7ƒ<qÜ∏W¸y(!46¥-Ù„–a¡aÜ∞ÉaÜWÜÔ	øø@∞@π`l¡›ßYƒéà…H,≤$Ú˝»…(«(Y‘h‘7—Œ—äËù—˜b<b*bˆ≈<éıã’«~˚L&Y&9áƒ%∆u«Mƒs‚s„á„øNpJP%ÏMòIJlN<ûDHJI⁄êtCj'ïKwKgíCíó%üN°ßdßß|ìÍô™O=ñß%ßmLªΩ–u°v·x:Hó¶oLøì!»®…¯C&13#s$Û/Y¢¨ñ¨≥Ÿ‹Ï‚Ï=ŸOsbs˙rnÂ∫ÁsOÊ1ÛäÚvÁ=ÀèÀÔœü\‰ªhŸ¢Û÷ÍÇ#Ö§¬º¬ùÖ≥ã„oZ<]T‘Ut}â`I√ísK≠óV-˝§òY,+>TB(…/ŸSÚÉ,]6*õ-ïñæW:#ó»7À*¢ä eøÚ^YDYŸ}UÑj£ÍAyT˘`˘#µD=¨˛∂"©b{≈≥ Ù +¨ Ø:†!kJ4Gµm•ˆtµ}uCı%ùóÆK7YV≥©fFü¢ﬂY’.©=b‡·?SåÓ∆ï∆©∫»∫ë∫Áıyıáÿ⁄ÜçûçkÔ5%4˝¶mñ7ülqlioôZ≥lG+‘Z⁄z≤Õπ≠≥mzy‚Ú]Ì‘ˆ ˆ?u¯uÙw|ø"≈±NªŒÂùwW&Æ‹€e÷•Ô∫±*|’ˆ’ËjıÍâ5k∂¨y›≠Ë˛¢«Øg∞Áá^yÔkEká÷˛∏Æl›D_pﬂ∂ıƒı⁄ı◊7Dmÿ’œÓoÍøª1m„·l†{‡˚M≈õŒnﬂL›l‹<9î˙O §[˛ò∏ô$ôêô¸öhö’õBõØúúâú˜ùdù“û@ûÆüüãü˙†i†ÿ°G°∂¢&¢ñ££v£Ê§V§«•8•©¶¶ã¶˝ßnß‡®R®ƒ©7©©™™è´´u´È¨\¨–≠D≠∏Æ-Æ°ØØã∞ ∞u∞Í±`±÷≤K≤¬≥8≥Æ¥%¥úµµä∂∂y∂∑h∑‡∏Y∏—πJπ¬∫;∫µª.ªßº!ºõΩΩèæ
+æÑæˇøzøı¿p¿Ï¡g¡„¬_¬€√X√‘ƒQƒŒ≈K≈»∆F∆√«A«ø»=»º…:…π 8 ∑À6À∂Ã5ÃµÕ5ÕµŒ6Œ∂œ7œ∏–9–∫—<—æ“?“¡”D”∆‘I‘À’N’—÷U÷ÿ◊\◊‡ÿdÿËŸlŸÒ⁄v⁄˚€Ä‹‹ä››ñﬁﬁ¢ﬂ)ﬂØ‡6‡Ω·D·Ã‚S‚€„c„Î‰s‰¸ÂÑÊÊñÁÁ©Ë2ËºÈFÈ–Í[ÍÂÎpÎ˚ÏÜÌÌúÓ(Ó¥Ô@ÔÃXÂÒrÒˇÚåÛÛßÙ4Ù¬ıPıﬁˆmˆ˚˜ä¯¯®˘8˘«˙W˙Á˚w¸¸ò˝)˝∫˛K˛‹ˇmˇˇ ˜ÑÛ˚endstreamendobj11 0 obj<</CreationDate(D:20120916115705+09'00')/Creator(Adobe Illustrator CS6 \(Macintosh\))/ModDate(D:20120916115705+09'00')/Producer(Adobe PDF library 10.01)/Title(slateTemplate)>>endobjxref0 120000000000 65535 f
+0000000016 00000 n
+0000000076 00000 n
+0000042955 00000 n
+0000000000 00000 f
+0000043006 00000 n
+0000043261 00000 n
+0000043903 00000 n
+0000043791 00000 n
+0000043665 00000 n
+0000043937 00000 n
+0000046585 00000 n
+trailer<</Size 12/Root 1 0 R/Info 11 0 R/ID[<A6DF6E274C964AC69A81A7859A1A0DE0><6183481130AE42AF91FC97BFCFA36EB7>]>>startxref46777%%EOF


### PR DESCRIPTION
I've created a vector NSStatusItem icon for Slate (PDF format). It uses the system's template styling and thus matches the standard system style.

It looks great with HiDPI (retina) resolutions and will work with even pre-10.6 versions of OS X.
