### PR TITLE
Update 'Assistive Devices' error message for Mountain Lion

### DIFF
--- a/Slate/SlateAppDelegate.m
+++ b/Slate/SlateAppDelegate.m
@@ -404,14 +404,16 @@ OSStatus OnModifiersChangedEvent(EventHandlerCallRef nextHandler, EventRef theEv
   // Check if Accessibility API is enabled
   if (!AXAPIEnabled()) {
     NSAlert *alert = [[NSAlert alloc] init];
-    [alert addButtonWithTitle:@"Quit"];
-    [alert addButtonWithTitle:@"Skip"];
-    [alert setMessageText:[NSString stringWithFormat:@"ERROR Access for assistive devices is not enabled. Please enable it."]];
-    [alert setInformativeText:[NSString stringWithFormat:@"System Preferences > Accessibility > \"Enable access for assistive devices\"."]];
-    [alert setAlertStyle:NSWarningAlertStyle];
+    [alert addButtonWithTitle:@"Yes"];
+    [alert addButtonWithTitle:@"No"];
+    [alert setMessageText:[NSString stringWithFormat:@"Slate requires \"Access for assistive devices\" to be enabled. Would you like to enable it?"]];
+    [alert setInformativeText:[NSString stringWithFormat:@"You may be prompted for your administrator password."]];
+    [alert setAlertStyle:NSCriticalAlertStyle];
     if ([alert runModal] == NSAlertFirstButtonReturn) {
-      SlateLogger(@"User selected exit");
-      [NSApp terminate:nil];
+      SlateLogger(@"User wants to enable Access for assistive devices");
+      NSDictionary* errorDictionary;
+      NSAppleScript* applescript = [[NSAppleScript alloc] initWithSource:@"tell application \"System Events\" to set UI elements enabled to true"];
+      [applescript executeAndReturnError:&errorDictionary];
     }
   }
 

--- a/Slate/SlateAppDelegate.m
+++ b/Slate/SlateAppDelegate.m
@@ -407,7 +407,7 @@ OSStatus OnModifiersChangedEvent(EventHandlerCallRef nextHandler, EventRef theEv
     [alert addButtonWithTitle:@"Quit"];
     [alert addButtonWithTitle:@"Skip"];
     [alert setMessageText:[NSString stringWithFormat:@"ERROR Access for assistive devices is not enabled. Please enable it."]];
-    [alert setInformativeText:[NSString stringWithFormat:@"Settings > Universal Access > Enable access for assistive devices."]];
+    [alert setInformativeText:[NSString stringWithFormat:@"System Preferences > Accessibility > \"Enable access for assistive devices\"."]];
     [alert setAlertStyle:NSWarningAlertStyle];
     if ([alert runModal] == NSAlertFirstButtonReturn) {
       SlateLogger(@"User selected exit");

--- a/Slate/SlateAppDelegate.m
+++ b/Slate/SlateAppDelegate.m
@@ -404,16 +404,21 @@ OSStatus OnModifiersChangedEvent(EventHandlerCallRef nextHandler, EventRef theEv
   // Check if Accessibility API is enabled
   if (!AXAPIEnabled()) {
     NSAlert *alert = [[NSAlert alloc] init];
-    [alert addButtonWithTitle:@"Yes"];
-    [alert addButtonWithTitle:@"No"];
-    [alert setMessageText:[NSString stringWithFormat:@"Slate requires \"Access for assistive devices\" to be enabled. Would you like to enable it?"]];
+    [alert addButtonWithTitle:@"Enable"];
+    [alert addButtonWithTitle:@"Quit"];
+    [alert setMessageText:[NSString stringWithFormat:@"Slate cannot run without \"Access for assistive devices\". Would you like to enable it?"]];
     [alert setInformativeText:[NSString stringWithFormat:@"You may be prompted for your administrator password."]];
     [alert setAlertStyle:NSCriticalAlertStyle];
-    if ([alert runModal] == NSAlertFirstButtonReturn) {
+    NSInteger alertIndex = [alert runModal];
+    if (alertIndex == NSAlertFirstButtonReturn) {
       SlateLogger(@"User wants to enable Access for assistive devices");
       NSDictionary* errorDictionary;
       NSAppleScript* applescript = [[NSAppleScript alloc] initWithSource:@"tell application \"System Events\" to set UI elements enabled to true"];
       [applescript executeAndReturnError:&errorDictionary];
+    }
+    else if (alertIndex == NSAlertSecondButtonReturn) {
+        SlateLogger(@"User selected quit");
+        [NSApp terminate:nil];
     }
   }
 


### PR DESCRIPTION
When launching Slate with 'access for assistive devices' disabled, the error message displays information that is incorrect when viewed on Mountain Lion.

Since this information then becomes incorrect on Snow Leopard and Lion, would it be worth it to check for the OS version and then display the correct error message for the OS version it's running on? I can do that instead if you'd like.

Cheers, and awesome work so far :)
