### PR TITLE
Update application About screen

### DIFF
--- a/Slate/en.lproj/Credits.rtf
+++ b/Slate/en.lproj/Credits.rtf
@@ -1,24 +1,21 @@
-{\rtf1\ansi\ansicpg1252\cocoartf1038\cocoasubrtf350
+{\rtf1\ansi\ansicpg1252\cocoartf1187\cocoasubrtf340
 {\fonttbl\f0\fswiss\fcharset0 Helvetica;}
 {\colortbl;\red255\green255\blue255;}
-\pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\ql\qnatural
+\paperw12240\paperh15840\vieww10800\viewh8400\viewkind0
+\pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720
 
-\f0\b\fs24 \cf0 Engineering:
+\f0\b\fs24 \cf0 Development
 \b0 \
-	Jigish Patel\
+Jigish Patel & {\field{\*\fldinst{HYPERLINK "https://github.com/jigish/slate/graphs/contributors"}}{\fldrslt Contributors\
+\
+}}
+\b Utilising{\field{\*\fldinst{HYPERLINK "https://github.com/jigish/slate/graphs/contributors"}}{\fldrslt 
+\b0 \
+JSONKit\
+Sparkle}}
+\b0 \
 \
 
-\b Testing:
+\b Licensing
 \b0 \
-	Hopefully not nobody\
-\
-
-\b Documentation:
-\b0 \
-	Definitely nobody\
-\
-
-\b With special thanks to:
-\b0 \
-	Mom\
-}
+GPLv3 \'a9 Jigish Patel 2011}


### PR DESCRIPTION
The project currently uses Xcode's auto generated Credits.rtf, meaning that the 'About Slate' screen isn't really that helpful.

I've amended that so it now gives users information about the:
- Project developers
- Third party frameworks
- Project license

Here is the old screen:
![](https://dl.dropbox.com/u/7675888/Slate_Old.png)
And my new, proposed screen:
![](https://dl.dropbox.com/u/7675888/Slate_New.png)
