### PR TITLE
Work on wider support for detecting display configuration changes

### DIFF
--- a/Slate/SlateConfig.h
+++ b/Slate/SlateConfig.h
@@ -71,3 +71,5 @@
 + (NSURL *)snapshotsFile;
 
 @end
+
+void onDisplayReconfiguration (CGDirectDisplayID display, CGDisplayChangeSummaryFlags flags, void *userInfo);

--- a/Slate/SlateConfig.m
+++ b/Slate/SlateConfig.m
@@ -71,6 +71,9 @@ static SlateConfig *_instance = nil;
     NSNotificationCenter *nc = [NSDistributedNotificationCenter defaultCenter];
     [nc addObserver:self selector:@selector(onScreenChange:) name:NOTIFICATION_SCREEN_CHANGE object:nil];
     [nc addObserver:self selector:@selector(onScreenChange:) name:NOTIFICATION_SCREEN_CHANGE_LION object:nil];
+    
+    // Listen for screen change notifications with Quartz
+    CGDisplayRegisterReconfigurationCallback(onDisplayReconfiguration, (__bridge void *)(self));
     //[nc addObserver:self selector:@selector(processNotification:) name:nil object:nil];
   }
   return self;
@@ -569,3 +572,8 @@ static SlateConfig *_instance = nil;
 }
 
 @end
+
+void onDisplayReconfiguration (CGDirectDisplayID display, CGDisplayChangeSummaryFlags flags, void *userInfo) {
+    NSLog(@"onDisplayReconfiguration");
+    [(__bridge id)userInfo onScreenChange:nil];
+}


### PR DESCRIPTION
This is more of a notification than a pull request - I think this Quartz method may provide a more stable and supportable way of updating the layouts when displays are added or removed, but right now it is added on top of your existing detection method.

Assuming the Quartz way is acceptable, I would suggest we remove the existing method entirely and rely fully on Quartz. I would note, however, that I only have Mountain Lion systems to test on, so if this API is unsuitable in earlier versions, some combination will be required!
