### PR TITLE
Attempted fix for issue #190

### DIFF
--- a/Slate/NSFileManager+ApplicationSupport.m
+++ b/Slate/NSFileManager+ApplicationSupport.m
@@ -44,7 +44,7 @@
   if (major >= 10 && minor >= 7) {
     success = [self createDirectoryAtURL:url withIntermediateDirectories:YES attributes:nil error:&error];
   } else {
-    success = [self createDirectoryAtPath:[url absoluteString] withIntermediateDirectories:YES attributes:nil error:&error];
+    success = [self createDirectoryAtPath:[url path] withIntermediateDirectories:YES attributes:nil error:&error];
   }
   if (!success) {
     if (errorOut) *errorOut = error;


### PR DESCRIPTION
These two methods on NSURL,

``` objective-c
- (NSString *)absoluteString
```

and

``` objective-c
- (NSString *)path
```

return different values. According to the docs, `path` is "suitable for input into methods of NSFileManager or NSPathUtilities", whereas `absoluteString` is not.

I don't have a copy of Snow Leopard handy, so someone will have to confirm this path does indeed fix #190 before merging.
