### PR TITLE
Fix bug where the statusItem wouldn't be highlighted upon selection

### DIFF
--- a/Slate/SlateAppDelegate.m
+++ b/Slate/SlateAppDelegate.m
@@ -475,7 +475,9 @@ OSStatus OnModifiersChangedEvent(EventHandlerCallRef nextHandler, EventRef theEv
 
   statusItem = [[NSStatusBar systemStatusBar] statusItemWithLength: NSVariableStatusItemLength];
   [statusItem setMenu:statusMenu];
-  [statusItem setImage:[NSImage imageNamed:@"status"]];
+  NSImage *statusImage = [NSImage imageNamed:@"status"];
+  [statusImage setTemplate:YES];
+  [statusItem setImage:statusImage];
   [statusItem setHighlightMode:YES];
 
   // Ensure no timer exists


### PR DESCRIPTION
Slate currently doesn't invert it's statusItem color when selected; this is conventional for OS X and makes Slate stand out in my menu bar.

Simply calling `- (void)setTemplate:(BOOL)isTemplate` on the NSImage is enough to rectify this problem.

Here's the before & after screenshots:
## ![Before](https://f.cloud.github.com/assets/712727/33335/f419657a-507e-11e2-961a-3f176f48782b.png)

![After](https://f.cloud.github.com/assets/712727/33336/f76b3546-507e-11e2-923d-8fc0b1c0597c.png)
