### PR TITLE
Cleanup initializer of Binding

### DIFF
--- a/Slate/Binding.m
+++ b/Slate/Binding.m
@@ -53,6 +53,7 @@ static NSDictionary *dictionary = nil;
   if (self) {
     UInt32 theKeyCode = 0;
     UInt32 theModifiers = 0;
+    NSNumber *theModalKey;
     // bind <key:modifiers|modal-key> <op> <parameters>
     NSMutableArray *tokens = [[NSMutableArray alloc] initWithCapacity:10];
     [StringTokenizer tokenize:binding into:tokens maxTokens:3];
@@ -63,13 +64,9 @@ static NSDictionary *dictionary = nil;
     NSArray *keyAndModifiers = [keystroke componentsSeparatedByString:COLON];
     if ([keyAndModifiers count] >= 1) {
       theKeyCode = (UInt32)[[[Binding asciiToCodeDict] objectForKey:[keyAndModifiers objectAtIndex:0]] integerValue];
-      [self setModalKey:nil];
       if ([keyAndModifiers count] >= 2) {
-        NSNumber *theModalKey = [[Binding asciiToCodeDict] objectForKey:[keyAndModifiers objectAtIndex:1]];
-        if (theModalKey != nil) {
-          // modal no modifier case
-          [self setModalKey:theModalKey];
-        } else {
+        theModalKey = [[Binding asciiToCodeDict] objectForKey:[keyAndModifiers objectAtIndex:1]];
+        if (theModalKey == nil) {
           // normal case
           NSArray *modifiersArray = [[keyAndModifiers objectAtIndex:1] componentsSeparatedByCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@",;"]];
           NSEnumerator *modEnum = [modifiersArray objectEnumerator];
@@ -86,9 +83,7 @@ static NSDictionary *dictionary = nil;
               theModifiers += shiftKey;
             } else if ([mod isEqualToString:FUNCTION]) {
               theModifiers += FUNCTION_KEY;
-            } else if (theModalKey != nil) { // modal key with modifiers
-              [self setModalKey:theModalKey];
-            } else {
+            } else if (theModalKey == nil) {
               SlateLogger(@"ERROR: Unrecognized modifier '%@'", mod);
               @throw([NSException exceptionWithName:@"Unrecognized Modifier" reason:[NSString stringWithFormat:@"Unrecognized modifier '%@' in '%@'", mod, binding] userInfo:nil]);
             }
@@ -129,6 +124,7 @@ static NSDictionary *dictionary = nil;
 
     keyCode = theKeyCode;
     modifiers = theModifiers;
+    modalKey = theModalKey;
     op = theOp;
     repeat = theRepeat;
   }

--- a/Slate/Binding.m
+++ b/Slate/Binding.m
@@ -51,6 +51,7 @@ static NSDictionary *dictionary = nil;
 - (id)initWithString:(NSString *)binding {
   self = [self init];
   if (self) {
+    UInt32 theModifiers = 0;
     // bind <key:modifiers|modal-key> <op> <parameters>
     NSMutableArray *tokens = [[NSMutableArray alloc] initWithCapacity:10];
     [StringTokenizer tokenize:binding into:tokens maxTokens:3];
@@ -61,7 +62,6 @@ static NSDictionary *dictionary = nil;
     NSArray *keyAndModifiers = [keystroke componentsSeparatedByString:COLON];
     if ([keyAndModifiers count] >= 1) {
       [self setKeyCode:(UInt32)[[[Binding asciiToCodeDict] objectForKey:[keyAndModifiers objectAtIndex:0]] integerValue]];
-      [self setModifiers:0];
       [self setModalKey:nil];
       if ([keyAndModifiers count] >= 2) {
         NSNumber *theModalKey = [[Binding asciiToCodeDict] objectForKey:[keyAndModifiers objectAtIndex:1]];
@@ -76,15 +76,15 @@ static NSDictionary *dictionary = nil;
           while (mod) {
             theModalKey = [[Binding asciiToCodeDict] objectForKey:mod];
             if ([mod isEqualToString:CONTROL]) {
-              modifiers += controlKey;
+              theModifiers += controlKey;
             } else if ([mod isEqualToString:OPTION]) {
-              modifiers += optionKey;
+              theModifiers += optionKey;
             } else if ([mod isEqualToString:COMMAND]) {
-              modifiers += cmdKey;
+              theModifiers += cmdKey;
             } else if ([mod isEqualToString:SHIFT]) {
-              modifiers += shiftKey;
+              theModifiers += shiftKey;
             } else if ([mod isEqualToString:FUNCTION]) {
-              modifiers += FUNCTION_KEY;
+              theModifiers += FUNCTION_KEY;
             } else if (theModalKey != nil) { // modal key with modifiers
               [self setModalKey:theModalKey];
             } else {
@@ -124,6 +124,8 @@ static NSDictionary *dictionary = nil;
     if ([op isKindOfClass:[SwitchOperation class]]) {
       [(SwitchOperation *)op setModifiers:modifiers];
     }
+
+    modifiers = theModifiers;
   }
 
   return self;

--- a/Slate/Binding.m
+++ b/Slate/Binding.m
@@ -107,25 +107,26 @@ static NSDictionary *dictionary = nil;
       }
     }
 
-    [self setOp:[Operation operationFromString:[tokens objectAtIndex:2]]];
+    Operation *theOp = [Operation operationFromString:[tokens objectAtIndex:2]];
 
-    if (op == nil) {
+    if (theOp == nil) {
       SlateLogger(@"ERROR: Unable to create binding");
       @throw([NSException exceptionWithName:@"Unable To Create Binding" reason:[NSString stringWithFormat:@"Unable to create '%@'", binding] userInfo:nil]);
     }
 
     @try {
-      [op testOperation];
+      [theOp testOperation];
     } @catch (NSException *ex) {
       SlateLogger(@"ERROR: Unable to test binding '%@'", binding);
       @throw([NSException exceptionWithName:@"Unable To Parse Binding" reason:[NSString stringWithFormat:@"Unable to parse '%@' in '%@'", [ex reason], binding] userInfo:nil]);
     }
 
-    if ([op isKindOfClass:[SwitchOperation class]]) {
+    if ([theOp isKindOfClass:[SwitchOperation class]]) {
       [(SwitchOperation *)op setModifiers:modifiers];
     }
 
     modifiers = theModifiers;
+    op = theOp;
   }
 
   return self;

--- a/Slate/Binding.m
+++ b/Slate/Binding.m
@@ -51,6 +51,7 @@ static NSDictionary *dictionary = nil;
 - (id)initWithString:(NSString *)binding {
   self = [self init];
   if (self) {
+    UInt32 theKeyCode = 0;
     UInt32 theModifiers = 0;
     // bind <key:modifiers|modal-key> <op> <parameters>
     NSMutableArray *tokens = [[NSMutableArray alloc] initWithCapacity:10];
@@ -61,7 +62,7 @@ static NSDictionary *dictionary = nil;
     NSString *keystroke = [tokens objectAtIndex:1];
     NSArray *keyAndModifiers = [keystroke componentsSeparatedByString:COLON];
     if ([keyAndModifiers count] >= 1) {
-      [self setKeyCode:(UInt32)[[[Binding asciiToCodeDict] objectForKey:[keyAndModifiers objectAtIndex:0]] integerValue]];
+      theKeyCode = (UInt32)[[[Binding asciiToCodeDict] objectForKey:[keyAndModifiers objectAtIndex:0]] integerValue];
       [self setModalKey:nil];
       if ([keyAndModifiers count] >= 2) {
         NSNumber *theModalKey = [[Binding asciiToCodeDict] objectForKey:[keyAndModifiers objectAtIndex:1]];
@@ -126,6 +127,7 @@ static NSDictionary *dictionary = nil;
       [(SwitchOperation *)op setModifiers:modifiers];
     }
 
+    keyCode = theKeyCode;
     modifiers = theModifiers;
     op = theOp;
     repeat = theRepeat;

--- a/Slate/Binding.m
+++ b/Slate/Binding.m
@@ -97,12 +97,13 @@ static NSDictionary *dictionary = nil;
       }
     }
 
+    BOOL theRepeat = NO;
     NSArray *repeatOps = [[[SlateConfig getInstance] getConfig:REPEAT_ON_HOLD_OPS] componentsSeparatedByString:COMMA];
     for (NSInteger i = 0; i < [repeatOps count]; i++) {
       NSMutableString *opStr = [[NSMutableString alloc] initWithCapacity:10];
       [StringTokenizer firstToken:[tokens objectAtIndex:2] into:opStr];
       if ([opStr isEqualToString:[repeatOps objectAtIndex:i]]) {
-        [self setRepeat:YES];
+        theRepeat = YES;
         break;
       }
     }
@@ -127,6 +128,7 @@ static NSDictionary *dictionary = nil;
 
     modifiers = theModifiers;
     op = theOp;
+    repeat = theRepeat;
   }
 
   return self;


### PR DESCRIPTION
For the `javascript` branch I needed to create Binding objects with a specific pre-existing `Operation` instance so I cleaned up and split the initializer into two methods.
