### PR TITLE
Fix for passing quoted args with spaces to shell()

### DIFF
--- a/Slate/ShellUtils.m
+++ b/Slate/ShellUtils.m
@@ -87,7 +87,7 @@
 
 + (NSString *)run:(NSString *)commandAndArgs wait:(BOOL)wait path:(NSString *)path {
   NSMutableArray *commandAndArgsTokens = [NSMutableArray array];
-  [StringTokenizer tokenize:commandAndArgs into:commandAndArgsTokens];
+  [StringTokenizer tokenize:commandAndArgs into:commandAndArgsTokens quoteChars:[NSCharacterSet characterSetWithCharactersInString:@"'\""]];
   if ([commandAndArgsTokens count] < 1) {
     SlateLogger(@"ERROR: Invalid Shell Parameter '%@'", commandAndArgs);
     @throw([NSException exceptionWithName:@"Invalid Shell Parameter" reason:[NSString stringWithFormat:@"Invalid Shell Parameter '%@'.", commandAndArgs] userInfo:nil]);

--- a/SlateTests/TestShellUtils.m
+++ b/SlateTests/TestShellUtils.m
@@ -45,4 +45,12 @@
   STAssertEquals([task terminationStatus], 15, @"Status should be 15");
 }
 
+- (void)testRunWithQuotedArgs {
+  NSString *result = [ShellUtils run:@"/bin/echo 'with single' \"and double quotes\"" wait:YES path:@"/"];
+  NSError *err = nil;
+  NSRegularExpression *testRegex = [NSRegularExpression regularExpressionWithPattern:@"with single and double quotes" options:0 error:&err];
+  int found = [testRegex numberOfMatchesInString:result options:0 range:NSMakeRange(0, [result length])];
+  STAssertEquals(found, 1, @"Result should include all strings");
+}
+
 @end


### PR DESCRIPTION
Before, passing a command with quoted arguments that contained spaces to 
slate.shell() produced an error. This works now.

I'm not used to ObjectiveC, so please be lenient. I had quite some
problems getting the tests to run and then, in my test, result also
contained "GC: forcing GC OFF because OBJC_DISABLE_GC is set" which is
why I used a regular expression to test the result, which isn't too
clean. Maybe you know a better way to test this.
