### PR TITLE
tokenize shell command with quote

### DIFF
--- a/Slate/ShellOperation.m
+++ b/Slate/ShellOperation.m
@@ -80,7 +80,7 @@
       @throw([NSException exceptionWithName:[NSString stringWithFormat:@"Invalid %@", name] reason:[NSString stringWithFormat:@"Invalid %@ '%@'", name, value] userInfo:nil]);
     }
     NSMutableArray *commandAndArgsTokens = [NSMutableArray array];
-    [StringTokenizer tokenize:value into:commandAndArgsTokens];
+    [StringTokenizer tokenize:value into:commandAndArgsTokens quoteChars:[NSCharacterSet characterSetWithCharactersInString:QUOTES]];
     if ([commandAndArgsTokens count] < 1) {
       SlateLogger(@"ERROR: Invalid Shell Parameter '%@'", value);
       @throw([NSException exceptionWithName:@"Invalid Shell Parameter" reason:[NSString stringWithFormat:@"Invalid Shell Parameter '%@'.", value] userInfo:nil]);


### PR DESCRIPTION
I wrote .slate.js

``` js
var launch_and_focus = function (target) {
    return function (win) {
        var apps = [];
        S.eachApp(function (app) { apps.push(app.name()); });
        if (! _.find(apps, function (name) { return name === target; })) {
            win.doOperation(
                S.operation('shell', {
                    command: "/usr/bin/open -a '" + target + "'",
                    waithFoeExit: true
                })
            );
        }
        win.doOperation(S.operation('focus', { app: target }));
    };
};
S.bind('i:ctrl,cmd', launch_and_focus('iTerm'));
S.bind('g:ctrl,cmd', launch_and_focus('Google Chrome'));
```

if app exists, focus at app. if app doesn't exist, launch app by "open" command.
but this doesn't work on 'Google Chrome'. shell command was parsed as
`/usr/bin/open`, `-a`, `'Google` and `Chrome'` ...
shell command should be tokenized with quote.
