### PR TITLE
JavaScript window context settings

### DIFF
--- a/Slate/HintOperation.m
+++ b/Slate/HintOperation.m
@@ -31,6 +31,7 @@
 #import "SlateLogger.h"
 #import "ExpressionPoint.h"
 #import "RunningApplications.h"
+#import "JSWindowWrapper.h"
 
 @implementation HintOperation
 
@@ -117,8 +118,11 @@ static const UInt32 ESC_HINT_ID = 10001;
   // now need to flip y coord
   tl.y = [screen frame].size.height - ([sw isMainScreen:screenId] ? MAIN_MENU_HEIGHT : 0) - tl.y;
   NSMutableDictionary *values = [[sw getScreenAndWindowValues:screenId window:NSMakeRect(tl.x, tl.y, wSize.width, wSize.height) newSize:wSize] mutableCopy];
-  float whHeight = [ExpressionPoint expToFloat:[[SlateConfig getInstance] getConfig:WINDOW_HINTS_HEIGHT] withDict:values];
-  float whWidth = [ExpressionPoint expToFloat:[[SlateConfig getInstance] getConfig:WINDOW_HINTS_WIDTH] withDict:values];
+  // Wrap the window in a JSWindowWrapper so that we can pass to the slate config loader so that the window settings
+  // can respond to the current window being overlayed
+  JSWindowWrapper *window = [[JSWindowWrapper alloc] initWithAccessibilityWrapper:aw screenWrapper:sw];
+  float whHeight = [ExpressionPoint expToFloat:[[SlateConfig getInstance] getConfig:WINDOW_HINTS_HEIGHT forWindow:window] withDict:values];
+  float whWidth = [ExpressionPoint expToFloat:[[SlateConfig getInstance] getConfig:WINDOW_HINTS_WIDTH forWindow:window] withDict:values];
   [values setObject:[NSNumber numberWithFloat:whWidth] forKey:WINDOW_HINTS_WIDTH];
   [values setObject:[NSNumber numberWithFloat:whHeight] forKey:WINDOW_HINTS_HEIGHT];
   // these two arrays are guarenteed to be the same size because of testOperation

--- a/Slate/JSController.h
+++ b/Slate/JSController.h
@@ -35,6 +35,19 @@
 - (void)runCallbacks:(NSString *)what payload:(id)payload;
 - (NSString *)addCallableFunction:(WebScriptObject *)function;
 - (id)runCallableFunction:(NSString *)key;
+/**
+ * Run a function by name passing in an argument
+ *
+ * This method looks up a function by name, then runs it and passes argument as the first (and only) argument to the
+ * function. This method will return the value returned by the function. If the function cannot be found by name, then
+ * this function will return nil.
+ *
+ * @param runCallableFunction The name of the function to run
+ * @param withArgument        The argument to pass into the function as the first parameter
+ *
+ * @return                    The return value of the function, or nil if the function cannot be found.
+ */
+- (id)runCallableFunction:(NSString *)functionName withArgument:(id)argument;
 - (id)runFunction:(WebScriptObject*)function;
 - (id)runFunction:(WebScriptObject *)function withArg:(id)arg;
 - (id)unmarshall:(id)obj;

--- a/Slate/JSController.m
+++ b/Slate/JSController.m
@@ -77,6 +77,15 @@ static NSDictionary *jscJsMethods;
   return [self runFunction:func];
 }
 
+- (id)runCallableFunction:(NSString *)functionName withArgument:(id)argument {
+	// Find the function by name
+	WebScriptObject *function = [functions objectForKey:functionName];
+	// If the function wasn't found, then return nil instead of trying to call a non-existant function
+	if(function == nil) return nil;
+	// Run the function and return the result
+	return [self runFunction:function withArg:argument];
+}
+
 - (id)runFunction:(WebScriptObject *)function {
   [scriptObject setValue:function forKey:@"_slate_callback"];
   return [self run:@"window._slate_callback();"];

--- a/Slate/SlateConfig.h
+++ b/Slate/SlateConfig.h
@@ -60,6 +60,19 @@
 - (double)getDoubleConfig:(NSString *)key;
 - (float)getFloatConfig:(NSString *)key;
 - (NSString *)getConfig:(NSString *)key;
+/*!
+ * Allows for window-specific configurations
+ *
+ * This method will load a configuration value just like getConfig. However, it will inject window into the JavaScript
+ * context prior to evaluating configuration properties. This allows you to make a configuration property a function
+ * that returns different values depending on the window that is active at the time.
+ *
+ * @param getConfig The name of the configuration value to look up
+ * @param forWindow The window for which to return configuration values
+ *
+ * @return          The value of the configuration parameter as a string
+ */
+- (NSString *)getConfig:(NSString * const)key forWindow:(id)window;
 - (NSString *)getConfigDefault:(NSString *)key;
 - (NSString *)getConfig:(NSString *)key app:(NSString *)app;
 - (NSArray *)getArrayConfig:(NSString *)key;

--- a/Slate/SlateConfig.m
+++ b/Slate/SlateConfig.m
@@ -109,6 +109,24 @@ static SlateConfig *_instance = nil;
   return c;
 }
 
+- (NSString *)getConfig:(NSString * const)key forWindow:(id)window {
+	// Look up the setting from the config dictionary
+	NSString* setting = [configs objectForKey:key];
+
+	// If this setting is a javascript setting, then allow special javascript calculations
+	if([setting hasPrefix:@"_javascript_::"]) {
+		// Get the name of the function by stripping the leading _javascript_:: tag from it
+		NSString *functionKey = [setting substringFromIndex:14];
+		// At this point we're assuming the string is a function, so run it (passing the window as a parameter)
+		id result = [[JSController getInstance] runCallableFunction:functionKey withArgument:window];
+		// Convert the return value to a string for returning
+		setting = [NSString stringWithFormat:@"%@", result];
+	}
+
+	// Return the value as it currently exists
+	return setting;
+}
+
 - (void)setConfig:(NSString *)key to:(NSString *)value {
   [configs setObject:value forKey:key];
 }


### PR DESCRIPTION
Made a change that lets javascript load config values in the context of a window so that if that config value is a function, then it can respond to the currently active window. 

The purpose was so that I could put javascript code in the windowHints\* config settings which would respond to the window the hint was for.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jigish/slate/274)
<!-- Reviewable:end -->
