### PR TITLE
Fix js snapshot operations

### DIFF
--- a/Slate/ActivateSnapshotOperation.m
+++ b/Slate/ActivateSnapshotOperation.m
@@ -85,7 +85,7 @@
       @throw([NSException exceptionWithName:[NSString stringWithFormat:@"Invalid %@", _name] reason:[NSString stringWithFormat:@"Invalid %@ '%@'", _name, value] userInfo:nil]);
       return;
     }
-    [self setName:_name];
+    [self setName:value];
   } else if ([_name isEqualToString:OPT_DELETE]) {
     if (![value isKindOfClass:[NSValue class]] && ![value isKindOfClass:[NSString class]] && ![value isKindOfClass:[NSNumber class]]) {
       @throw([NSException exceptionWithName:[NSString stringWithFormat:@"Invalid %@", _name] reason:[NSString stringWithFormat:@"Invalid %@ '%@'", _name, value] userInfo:nil]);

--- a/Slate/DeleteSnapshotOperation.m
+++ b/Slate/DeleteSnapshotOperation.m
@@ -81,7 +81,7 @@
       @throw([NSException exceptionWithName:[NSString stringWithFormat:@"Invalid %@", _name] reason:[NSString stringWithFormat:@"Invalid %@ '%@'", _name, value] userInfo:nil]);
       return;
     }
-    [self setName:_name];
+    [self setName:value];
   } else if ([_name isEqualToString:OPT_ALL]) {
     if (![value isKindOfClass:[NSValue class]] && ![value isKindOfClass:[NSString class]] && ![value isKindOfClass:[NSNumber class]]) {
       @throw([NSException exceptionWithName:[NSString stringWithFormat:@"Invalid %@", _name] reason:[NSString stringWithFormat:@"Invalid %@ '%@'", _name, value] userInfo:nil]);

--- a/Slate/SnapshotOperation.m
+++ b/Slate/SnapshotOperation.m
@@ -109,7 +109,7 @@
       @throw([NSException exceptionWithName:[NSString stringWithFormat:@"Invalid %@", _name] reason:[NSString stringWithFormat:@"Invalid %@ '%@'", _name, value] userInfo:nil]);
       return;
     }
-    [self setName:_name];
+    [self setName:value];
   } else if ([_name isEqualToString:OPT_SAVE]) {
     if (![value isKindOfClass:[NSValue class]] && ![value isKindOfClass:[NSString class]] && ![value isKindOfClass:[NSNumber class]]) {
       @throw([NSException exceptionWithName:[NSString stringWithFormat:@"Invalid %@", _name] reason:[NSString stringWithFormat:@"Invalid %@ '%@'", _name, value] userInfo:nil]);


### PR DESCRIPTION
JS snapshot operations (snapshot, delete-snapshot and active-snapshot) don't use the given name but the constant string "name".

The problem is that the `parseOption` method sets the name property to the name of the parsed option instead of the value.  This pull request fixes this.
