### PR TITLE
Fixes bug where Slate crashes if window hints is triggered in certain contexts (Emacs.app or Calendar.app visible)

### DIFF
--- a/Slate/AccessibilityWrapper.m
+++ b/Slate/AccessibilityWrapper.m
@@ -242,7 +242,7 @@ static NSDictionary *unselectableApps = nil;
 
 + (NSString *)getTitle:(AXUIElementRef)window {
   [AccessibilityWrapper createSystemWideElement];
-  CFTypeRef _title;
+  CFTypeRef _title = NULL;
   if (AXUIElementCopyAttributeValue(window, (CFStringRef)NSAccessibilityTitleAttribute, (CFTypeRef *)&_title) == kAXErrorSuccess) {
     NSString *title = (__bridge NSString *) _title;
     if (_title != NULL) CFRelease(_title);


### PR DESCRIPTION
NOTE: This bug is not reproducible if .slate has <code>config windowHintsIgnoreHiddenWindows false</code>
Bug previously raised in this issue:
https://github.com/jigish/slate/issues/303

Patch is simply a one line change to initialize local variable in AccessibilityWrapper.m:getTitle:window which subsequently fixes the bug.
