### PR TITLE
Added missing delete key

### DIFF
--- a/README.md
+++ b/README.md
@@ -683,6 +683,7 @@ Please send all questions, bug reports, suggestions, or general commentary to [J
     pageUp
     q
     r
+    rdelete
     return
     right
     s

--- a/Slate/ASCIIToCode.plist
+++ b/Slate/ASCIIToCode.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>rdelete</key>
+	<integer>117</integer>
 	<key>&apos;</key>
 	<integer>39</integer>
 	<key>,</key>


### PR DESCRIPTION
There is a missing key in the mappings, the delete key that is left to the end key.

To avoid conflicts with the present delete key (the one that acts as backspace) I called this the 'rdelete' key.
