### PR TITLE
Updating README with info on new location of 10.9's per-app Accessibility API setting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ Big thanks to [philc](https://github.com/philc) for the Window Hints idea (and i
 
 **NEW Installation Instructions**
 
-**Note:** You must turn on the Accessibility API by checking System Preferences > Universal Access > Enable access for assistive devices
+**Note:** You must turn on the Accessibility API by enabling access for assistive devices:
+* on pre-10.9 systems, checking System Preferences > Universal Access > Enable access for assistive devices
+* on 10.9: launch Slate, then System Prefereces > Security & Privacy > Privacy tab > Accessibility > select checkbox
 
 ### Direct Download ###
 


### PR DESCRIPTION
The "enable access for assistive devices" has changed to a per-app setting, now under the "Security and Privacy" System Pref. See http://support.apple.com/kb/HT6026.
