### PR TITLE
Expose bundle identifier in app object

### DIFF
--- a/Slate/JSApplicationWrapper.m
+++ b/Slate/JSApplicationWrapper.m
@@ -68,6 +68,10 @@ static NSDictionary *jsawJsMethods;
   return [app processIdentifier];
 }
 
+- (NSString *)bundleIdentifier {
+  return [app bundleIdentifier];
+}
+
 - (NSString *)name {
   return [app localizedName];
 }
@@ -114,6 +118,7 @@ static NSDictionary *jsawJsMethods;
   if (jsawJsMethods == nil) {
     jsawJsMethods = @{
       NSStringFromSelector(@selector(pid)): @"pid",
+      NSStringFromSelector(@selector(bundleIdentifier)): @"bundleIdentifier",
       NSStringFromSelector(@selector(name)): @"name",
       NSStringFromSelector(@selector(eachWindow:)): @"eachWindow",
       NSStringFromSelector(@selector(ewindow:)): @"ewindow",


### PR DESCRIPTION
This can be useful to distinguish between apps like Chrome and Chrome
Canary (which both report their name as "Google Chrome" but have bundle
identifiers `com.google.Chrome` and `com.google.Chrome.canary`
respectively).

This can be used in a `.slate.js` to do things like the following,
which is a layout that pushes Canary windows to the left half of the
screen and normal Chrome windows to the right half:

```
slate.layout('my-layout', {
  'Google Chrome': {
    operations: [function(window) {
      var app = window.app();
      if (app.bundleIdentifier() === 'com.google.Chrome.canary') {
        // code to push window left
      } else {
        // code to push window right
      }
    }],
    repeat: true,
  },
});
```
