### PR TITLE
Handle shell operations with spaces and quotes

### DIFF
--- a/Slate/ShellOperation.m
+++ b/Slate/ShellOperation.m
@@ -133,7 +133,7 @@
   }
   NSString *commandAndArgs = [tokens lastObject];
   NSMutableArray *commandAndArgsTokens = [NSMutableArray array];
-  [StringTokenizer tokenize:commandAndArgs into:commandAndArgsTokens];
+  [StringTokenizer tokenize:commandAndArgs into:commandAndArgsTokens quoteChars:[NSCharacterSet characterSetWithCharactersInString:QUOTES]];
   if ([commandAndArgsTokens count] < 1) {
     SlateLogger(@"ERROR: Invalid Parameters '%@'", shellOperation);
     @throw([NSException exceptionWithName:@"Invalid Parameters" reason:[NSString stringWithFormat:@"Invalid Parameters in '%@'. Shell operations require the following format: shell [wait] 'command'", shellOperation] userInfo:nil]);

--- a/SlateTests/TestShellUtils.m
+++ b/SlateTests/TestShellUtils.m
@@ -20,6 +20,7 @@
 
 #import "TestShellUtils.h"
 #import "ShellUtils.h"
+#import "ShellOperation.h"
 
 @implementation TestShellUtils
 
@@ -51,6 +52,13 @@
   NSRegularExpression *testRegex = [NSRegularExpression regularExpressionWithPattern:@"with single and double quotes" options:0 error:&err];
   int found = [testRegex numberOfMatchesInString:result options:0 range:NSMakeRange(0, [result length])];
   STAssertEquals(found, 1, @"Result should include all strings");
+}
+
+-(void)testShellOperationFromStringWithQuotesAndSpaces {
+    id operation = [ShellOperation shellOperationFromString:@"shell '/usr/bin/open -a \"Sublime Text\"'"];
+    int argumentCount = [[operation args] count];
+    
+    STAssertEquals(argumentCount, 2, @"The shell operation must only contain two arguments");
 }
 
 @end


### PR DESCRIPTION
A shell command which contains spaces and quotes would not run.

For example, this config line: `bind e:ctrl shell '/usr/bin/open -a "Sublime Text"`, would not run because `"Sublime Text"` would be split in to two arguments, not one.
