### PR TITLE
Don't lock up waiting for AXUI info from unresponsive apps.

### DIFF
--- a/Slate/RunningApplications.h
+++ b/Slate/RunningApplications.h
@@ -20,6 +20,10 @@
 
 #import <Foundation/Foundation.h>
 
+typedef int CGSConnectionID;
+CG_EXTERN CGSConnectionID CGSMainConnectionID(void);
+bool CGSEventIsAppUnresponsive(CGSConnectionID cid, const ProcessSerialNumber *psn);
+
 @interface RunningApplications : NSObject <NSFastEnumeration> {
   NSMutableArray *apps;
   NSMutableDictionary *appNameToApp;

--- a/Slate/RunningApplications.m
+++ b/Slate/RunningApplications.m
@@ -259,11 +259,19 @@ static void windowCallback(AXObserverRef observer, AXUIElementRef element, CFStr
     appToWindows = [NSMutableDictionary dictionary];
     pidToObserver = [NSMutableDictionary dictionary];
     titleToWindow = [NSMutableDictionary dictionary];
+    
+    pid_t pid;
+    ProcessSerialNumber psn;
+    CGSConnectionID conn = CGSMainConnectionID();
+    
     SlateLogger(@"------------------ Checking Running Applications ------------------");
     NSArray *appsArr = [[NSWorkspace sharedWorkspace] runningApplications];
     NSRunningApplication *currentApp = [NSRunningApplication currentApplication];
     for (NSRunningApplication *app in appsArr) {
-      if ([RunningApplications isAppSelectable:app]) {
+      pid = [app processIdentifier];
+      GetProcessForPID(pid, &psn);
+      bool unresponsive = CGSEventIsAppUnresponsive(conn, &psn);
+      if ([RunningApplications isAppSelectable:app] && !unresponsive) {
         SlateLogger(@"  Selectable: %@", [app localizedName]);
         [apps addObject:app];
         [appNameToApp setObject:app forKey:[app localizedName]];


### PR DESCRIPTION
Improve user experience by not querying unresponsive apps (with blocking calls) for information they won't provide.
