### PR TITLE
Fixed: Run applications whose name contain spaces.

### DIFF
--- a/Slate.xcodeproj/project.pbxproj
+++ b/Slate.xcodeproj/project.pbxproj
@@ -50,7 +50,7 @@
 		3BA1BA6E162F51760026774E /* TestShellUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 3BA1BA6D162F51760026774E /* TestShellUtils.m */; };
 		3BA7485913B1D0F500CFA792 /* MathUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 3BA7485813B1D0F500CFA792 /* MathUtils.m */; };
 		3BA85C9A16276DAB00FAAF0B /* Sparkle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3BA85C9916276DAB00FAAF0B /* Sparkle.framework */; };
-		3BA85C9B16276E9E00FAAF0B /* Sparkle.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 3BA85C9916276DAB00FAAF0B /* Sparkle.framework */; };
+		3BA85C9B16276E9E00FAAF0B /* Sparkle.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 3BA85C9916276DAB00FAAF0B /* Sparkle.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		3BADA37213A2C1ED009E21D8 /* AccessibilityWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 3BADA37113A2C1ED009E21D8 /* AccessibilityWrapper.m */; };
 		3BB5380413AEDA1B0005CFFC /* ScreenState.m in Sources */ = {isa = PBXBuildFile; fileRef = 3BB5380313AEDA190005CFFC /* ScreenState.m */; };
 		3BBD24BA1580206C00940ABF /* default.slate in Resources */ = {isa = PBXBuildFile; fileRef = 3BBD24B91580206C00940ABF /* default.slate */; };
@@ -657,7 +657,6 @@
 				47C4A2AB1384E8890066B6DE /* Sources */,
 				47C4A2AC1384E8890066B6DE /* Frameworks */,
 				47C4A2AD1384E8890066B6DE /* Resources */,
-				47C4A2AE1384E8890066B6DE /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -667,7 +666,7 @@
 			name = SlateTests;
 			productName = SlateTests;
 			productReference = 47C4A2B01384E8890066B6DE /* SlateTests.octest */;
-			productType = "com.apple.product-type.bundle";
+			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
 
@@ -675,7 +674,7 @@
 		47C4A2861384E8890066B6DE /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0450;
+				LastUpgradeCheck = 0730;
 			};
 			buildConfigurationList = 47C4A2891384E8890066B6DE /* Build configuration list for PBXProject "Slate" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -727,22 +726,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		47C4A2AE1384E8890066B6DE /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "# Run the unit tests in this test bundle.\n\"${SYSTEM_DEVELOPER_DIR}/Tools/RunUnitTests\"\n";
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		47C4A28B1384E8890066B6DE /* Sources */ = {
@@ -878,14 +861,26 @@
 		47C4A2BF1384E8890066B6DE /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = DEBUG;
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.6;
 				ONLY_ACTIVE_ARCH = YES;
@@ -896,11 +891,22 @@
 		47C4A2C01384E8890066B6DE /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.6;
 				SDKROOT = macosx;
@@ -911,7 +917,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
@@ -929,6 +934,7 @@
 				INFOPLIST_FILE = "Slate/Slate-Info.plist";
 				INSTALL_PATH = "$(LOCAL_APPS_DIR)";
 				MACOSX_DEPLOYMENT_TARGET = 10.6;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.slate.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
 			};
@@ -938,7 +944,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
@@ -956,6 +961,7 @@
 				INFOPLIST_FILE = "Slate/Slate-Info.plist";
 				INSTALL_PATH = "$(LOCAL_APPS_DIR)";
 				MACOSX_DEPLOYMENT_TARGET = 10.6;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.slate.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
 			};
@@ -965,24 +971,19 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/Slate.app/Contents/MacOS/Slate";
 				CLANG_ENABLE_OBJC_ARC = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
-				FRAMEWORK_SEARCH_PATHS = "$(DEVELOPER_LIBRARY_DIR)/Frameworks";
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "SlateTests/SlateTests-Prefix.pch";
 				INFOPLIST_FILE = "SlateTests/SlateTests-Info.plist";
-				OTHER_LDFLAGS = (
-					"-framework",
-					SenTestingKit,
-				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.slate.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUNDLE_LOADER)";
-				WRAPPER_EXTENSION = octest;
 			};
 			name = Debug;
 		};
@@ -990,24 +991,19 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/Slate.app/Contents/MacOS/Slate";
 				CLANG_ENABLE_OBJC_ARC = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				FRAMEWORK_SEARCH_PATHS = "$(DEVELOPER_LIBRARY_DIR)/Frameworks";
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "SlateTests/SlateTests-Prefix.pch";
 				INFOPLIST_FILE = "SlateTests/SlateTests-Info.plist";
-				OTHER_LDFLAGS = (
-					"-framework",
-					SenTestingKit,
-				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.slate.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUNDLE_LOADER)";
-				WRAPPER_EXTENSION = octest;
 			};
 			name = Release;
 		};

--- a/Slate/JSONKit/JSONKit.m
+++ b/Slate/JSONKit/JSONKit.m
@@ -677,7 +677,7 @@ static JKArray *_JKArrayCreate(id *objects, NSUInteger count, BOOL mutableCollec
   NSCParameterAssert((objects != NULL) && (_JKArrayClass != NULL) && (_JKArrayInstanceSize > 0UL));
   JKArray *array = NULL;
   if(JK_EXPECT_T((array = (JKArray *)calloc(1UL, _JKArrayInstanceSize)) != NULL)) { // Directly allocate the JKArray instance via calloc.
-    array->isa      = _JKArrayClass;
+    object_setClass(array, _JKArrayClass);
     if((array = [array init]) == NULL) { return(NULL); }
     array->capacity = count;
     array->count    = count;
@@ -926,7 +926,7 @@ static JKDictionary *_JKDictionaryCreate(id *keys, NSUInteger *keyHashes, id *ob
   NSCParameterAssert((keys != NULL) && (keyHashes != NULL) && (objects != NULL) && (_JKDictionaryClass != NULL) && (_JKDictionaryInstanceSize > 0UL));
   JKDictionary *dictionary = NULL;
   if(JK_EXPECT_T((dictionary = (JKDictionary *)calloc(1UL, _JKDictionaryInstanceSize)) != NULL)) { // Directly allocate the JKDictionary instance via calloc.
-    dictionary->isa      = _JKDictionaryClass;
+    object_setClass(dictionary, _JKDictionaryClass);
     if((dictionary = [dictionary init]) == NULL) { return(NULL); }
     dictionary->capacity = _JKDictionaryCapacityForCount(count);
     dictionary->count    = 0UL;

--- a/Slate/ShellOperation.m
+++ b/Slate/ShellOperation.m
@@ -133,7 +133,7 @@
   }
   NSString *commandAndArgs = [tokens lastObject];
   NSMutableArray *commandAndArgsTokens = [NSMutableArray array];
-  [StringTokenizer tokenize:commandAndArgs into:commandAndArgsTokens];
+  [StringTokenizer tokenize:commandAndArgs into:commandAndArgsTokens quoteChars:[NSCharacterSet characterSetWithCharactersInString:QUOTES]];
   if ([commandAndArgsTokens count] < 1) {
     SlateLogger(@"ERROR: Invalid Parameters '%@'", shellOperation);
     @throw([NSException exceptionWithName:@"Invalid Parameters" reason:[NSString stringWithFormat:@"Invalid Parameters in '%@'. Shell operations require the following format: shell [wait] 'command'", shellOperation] userInfo:nil]);

--- a/Slate/Slate-Info.plist
+++ b/Slate/Slate-Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleIconFile</key>
 	<string>icon.icns</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.slate.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/SlateTests/SlateTests-Info.plist
+++ b/SlateTests/SlateTests-Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.slate.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundlePackageType</key>

--- a/SlateTests/SlateTests.h
+++ b/SlateTests/SlateTests.h
@@ -18,10 +18,10 @@
 //  You should have received a copy of the GNU General Public License
 //  along with this program.  If not, see http://www.gnu.org/licenses
 
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 
 
-@interface SlateTests : SenTestCase {
+@interface SlateTests : XCTestCase {
 @private
 
 }

--- a/SlateTests/SlateTests.m
+++ b/SlateTests/SlateTests.m
@@ -39,7 +39,7 @@
 
 - (void)testExample
 {
-    STAssertTrue(true, @"Unit tests are not implemented yet in SlateTests");
+    XCTAssertTrue(true, @"Unit tests are not implemented yet in SlateTests");
 }
 
 @end

--- a/SlateTests/TestExpressionPoint.h
+++ b/SlateTests/TestExpressionPoint.h
@@ -18,8 +18,8 @@
 //  You should have received a copy of the GNU General Public License
 //  along with this program.  If not, see http://www.gnu.org/licenses
 
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 
-@interface TestExpressionPoint : SenTestCase
+@interface TestExpressionPoint : XCTestCase
 
 @end

--- a/SlateTests/TestExpressionPoint.m
+++ b/SlateTests/TestExpressionPoint.m
@@ -34,12 +34,12 @@
   NSString *x = @"x";
   NSString *y = @"y";
   ExpressionPoint *a = [[ExpressionPoint alloc] initWithX:x y:y];
-  STAssertEquals([a x], x, @"x should be x");
-  STAssertEquals([a y], y, @"y should be y");
+  XCTAssertEqual([a x], x, @"x should be x");
+  XCTAssertEqual([a y], y, @"y should be y");
   [a setX:y];
   [a setY:x];
-  STAssertEquals([a x], y, @"x should be y");
-  STAssertEquals([a y], x, @"y should be x");
+  XCTAssertEqual([a x], y, @"x should be y");
+  XCTAssertEqual([a y], x, @"y should be x");
 }
 
 - (void)testGetPointWithDict {
@@ -49,27 +49,27 @@
                         [NSNumber numberWithInteger:2], @"var3", nil];
   ExpressionPoint *a = [[ExpressionPoint alloc] initWithX:@"var1+var2" y:@"var1*var2"];
   NSPoint p = [a getPointWithDict:dict];
-  STAssertTrue(NSEqualPoints(p, NSMakePoint(15, 50)), @"Shit should work");
+  XCTAssertTrue(NSEqualPoints(p, NSMakePoint(15, 50)), @"Shit should work");
   [a setX:@"sqrt((var2/var3)*var1)+count({1,2,3})"]; // 5 + 3
   [a setY:@"var3**var2+sum({1,2,3})"]; // 1024 + 6
   p = [a getPointWithDict:dict];
-  STAssertTrue(NSEqualPoints(p, NSMakePoint(8, 1030)), @"Shit should work");
+  XCTAssertTrue(NSEqualPoints(p, NSMakePoint(8, 1030)), @"Shit should work");
   [a setX:@"min({1,2,3})+max({4,5,6})"]; // 1 + 6
   [a setY:@"average({1,2,3,4})+median({1,2,3,10,15})"]; // 2.5 + 3
   p = [a getPointWithDict:dict];
-  STAssertTrue(NSEqualPoints(p, NSMakePoint(7, 5.5)), @"Shit should work");
+  XCTAssertTrue(NSEqualPoints(p, NSMakePoint(7, 5.5)), @"Shit should work");
   [a setX:@"floor(3.9)+(stddev({1,2,3,4,5}))**2"]; // 3 + 2
   [a setY:@"log(1000)+ln(exp(5))"]; // 3 + 5
   p = [a getPointWithDict:dict];
-  STAssertTrue(NSEqualPoints(p, NSMakePoint(5, 8)), @"Shit should work");
+  XCTAssertTrue(NSEqualPoints(p, NSMakePoint(5, 8)), @"Shit should work");
   [a setX:@"ceiling(2.1)+abs(-2)"]; // 3 + 2
   [a setY:@"trunc(3.232472398472834723)"]; // 3
   p = [a getPointWithDict:dict];
-  STAssertTrue(NSEqualPoints(p, NSMakePoint(5, 3)), @"Shit should work");
+  XCTAssertTrue(NSEqualPoints(p, NSMakePoint(5, 3)), @"Shit should work");
   [a setX:@"random()"]; // 0 <= me < 1
   [a setY:@"randomn(10)"]; // 0 <= me < 10
   p = [a getPointWithDict:dict];
-  STAssertTrue(p.x >= 0 && p.x < 1 && p.y >= 0 && p.y < 10, @"Shit should work");
+  XCTAssertTrue(p.x >= 0 && p.x < 1 && p.y >= 0 && p.y < 10, @"Shit should work");
 }
 
 - (void)testGetSizeWithDict {
@@ -79,27 +79,27 @@
                         [NSNumber numberWithInteger:2], @"var3", nil];
   ExpressionPoint *a = [[ExpressionPoint alloc] initWithX:@"var1+var2" y:@"var1*var2"];
   NSSize p = [a getSizeWithDict:dict];
-  STAssertTrue(NSEqualSizes(p, NSMakeSize(15, 50)), @"Shit should work");
+  XCTAssertTrue(NSEqualSizes(p, NSMakeSize(15, 50)), @"Shit should work");
   [a setX:@"sqrt((var2/var3)*var1)+count({1,2,3})"]; // 5 + 3
   [a setY:@"var3**var2+sum({1,2,3})"]; // 1024 + 6
   p = [a getSizeWithDict:dict];
-  STAssertTrue(NSEqualSizes(p, NSMakeSize(8, 1030)), @"Shit should work");
+  XCTAssertTrue(NSEqualSizes(p, NSMakeSize(8, 1030)), @"Shit should work");
   [a setX:@"min({1,2,3})+max({4,5,6})"]; // 1 + 6
   [a setY:@"average({1,2,3,4})+median({1,2,3,10,15})"]; // 2.5 + 3
   p = [a getSizeWithDict:dict];
-  STAssertTrue(NSEqualSizes(p, NSMakeSize(7, 5.5)), @"Shit should work");
+  XCTAssertTrue(NSEqualSizes(p, NSMakeSize(7, 5.5)), @"Shit should work");
   [a setX:@"floor(3.9)+(stddev({1,2,3,4,5}))**2"]; // 3 + 2
   [a setY:@"log(1000)+ln(exp(5))"]; // 3 + 5
   p = [a getSizeWithDict:dict];
-  STAssertTrue(NSEqualSizes(p, NSMakeSize(5, 8)), @"Shit should work");
+  XCTAssertTrue(NSEqualSizes(p, NSMakeSize(5, 8)), @"Shit should work");
   [a setX:@"ceiling(2.1)+abs(-2)"]; // 3 + 2
   [a setY:@"trunc(3.232472398472834723)"]; // 3
   p = [a getSizeWithDict:dict];
-  STAssertTrue(NSEqualSizes(p, NSMakeSize(5, 3)), @"Shit should work");
+  XCTAssertTrue(NSEqualSizes(p, NSMakeSize(5, 3)), @"Shit should work");
   [a setX:@"random()"]; // 0 <= me < 1
   [a setY:@"randomn(10)"]; // 0 <= me < 10
   p = [a getSizeWithDict:dict];
-  STAssertTrue(p.width >= 0 && p.width < 1 && p.height >= 0 && p.height < 10, @"Shit should work");
+  XCTAssertTrue(p.width >= 0 && p.width < 1 && p.height >= 0 && p.height < 10, @"Shit should work");
 }
 
 @end

--- a/SlateTests/TestMathUtils.h
+++ b/SlateTests/TestMathUtils.h
@@ -18,8 +18,8 @@
 //  You should have received a copy of the GNU General Public License
 //  along with this program.  If not, see http://www.gnu.org/licenses
 
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 
-@interface TestMathUtils : SenTestCase
+@interface TestMathUtils : XCTestCase
 
 @end

--- a/SlateTests/TestMathUtils.m
+++ b/SlateTests/TestMathUtils.m
@@ -32,36 +32,36 @@
   NSRect f = NSMakeRect(0, 0, 1, 200);
   NSRect g = NSMakeRect(1000, 1000, 1, 1);
   NSRect h = NSMakeRect(1000, 1000, 101, 101);
-  STAssertFalse([MathUtils isRect:a biggerThan:b], @"0,0,100,100 should be smaller than 0,0,200,90");
-  STAssertFalse([MathUtils isRect:a biggerThan:c], @"0,0,100,100 should be smaller than 0,0,90,200");
-  STAssertFalse([MathUtils isRect:a biggerThan:d], @"0,0,100,100 should be smaller than 0,0,200,200");
-  STAssertTrue([MathUtils isRect:a biggerThan:e], @"0,0,100,100 should be bigger than 0,0,200,1");
-  STAssertTrue([MathUtils isRect:a biggerThan:f], @"0,0,100,100 should be bigger than 0,0,1,200");
-  STAssertTrue([MathUtils isRect:a biggerThan:g], @"0,0,100,100 should be bigger than 1000,1000,1,1");
-  STAssertFalse([MathUtils isRect:a biggerThan:h], @"0,0,100,100 should be smaller than 1000,1000,101,101");
+  XCTAssertFalse([MathUtils isRect:a biggerThan:b], @"0,0,100,100 should be smaller than 0,0,200,90");
+  XCTAssertFalse([MathUtils isRect:a biggerThan:c], @"0,0,100,100 should be smaller than 0,0,90,200");
+  XCTAssertFalse([MathUtils isRect:a biggerThan:d], @"0,0,100,100 should be smaller than 0,0,200,200");
+  XCTAssertTrue([MathUtils isRect:a biggerThan:e], @"0,0,100,100 should be bigger than 0,0,200,1");
+  XCTAssertTrue([MathUtils isRect:a biggerThan:f], @"0,0,100,100 should be bigger than 0,0,1,200");
+  XCTAssertTrue([MathUtils isRect:a biggerThan:g], @"0,0,100,100 should be bigger than 1000,1000,1,1");
+  XCTAssertFalse([MathUtils isRect:a biggerThan:h], @"0,0,100,100 should be smaller than 1000,1000,101,101");
 }
 
 - (void)testFlipYCoordinateOfRectWithReference {
   NSRect a = NSMakeRect(0, 0, 100, 100);
   NSRect b = NSMakeRect(0, 0, 1000, 1000);
   NSRect flipped = [MathUtils flipYCoordinateOfRect:a withReference:b];
-  STAssertTrue(NSEqualRects(flipped, NSMakeRect(0,900,100,100)), @"Flipping should work");
+  XCTAssertTrue(NSEqualRects(flipped, NSMakeRect(0,900,100,100)), @"Flipping should work");
   a = NSMakeRect(0,-100, 100, 1500);
   b = NSMakeRect(0, 0, 1000, 1000);
   flipped = [MathUtils flipYCoordinateOfRect:a withReference:b];
-  STAssertTrue(NSEqualRects(flipped, NSMakeRect(0,-400,100,1500)), @"Flipping should work");
+  XCTAssertTrue(NSEqualRects(flipped, NSMakeRect(0,-400,100,1500)), @"Flipping should work");
 }
 
 - (void)testScaleRectFactor {
   NSRect a = NSMakeRect(100, 200, 100, 200);
   NSRect scaled = [MathUtils scaleRect:a factor:2.0];
-  STAssertTrue(NSEqualRects(scaled, NSMakeRect(100,200,200,400)), @"Scaling should work");
+  XCTAssertTrue(NSEqualRects(scaled, NSMakeRect(100,200,200,400)), @"Scaling should work");
   a = NSMakeRect(100, 200, 100, 200);
   scaled = [MathUtils scaleRect:a factor:0.5];
-  STAssertTrue(NSEqualRects(scaled, NSMakeRect(100,200,50,100)), @"Scaling should work");
+  XCTAssertTrue(NSEqualRects(scaled, NSMakeRect(100,200,50,100)), @"Scaling should work");
   a = NSMakeRect(100, 200, 100, 200);
   scaled = [MathUtils scaleRect:a factor:2.5];
-  STAssertTrue(NSEqualRects(scaled, NSMakeRect(100,200,250,500)), @"Scaling should work");
+  XCTAssertTrue(NSEqualRects(scaled, NSMakeRect(100,200,250,500)), @"Scaling should work");
 }
 
 - (void)testWeightedIntersectionOfAndWeight {
@@ -70,23 +70,23 @@
   NSRect c = NSMakeRect(0, 0, 50, 50);
   NSRect d = NSMakeRect(50, 50, 100, 100);
   NSRect intersection = [MathUtils weightedIntersectionOf:a and:b weight:1];
-  STAssertTrue(NSEqualRects(intersection, NSMakeRect(0, 0, 0, 0)), @"Weighted Intersection should work");
+  XCTAssertTrue(NSEqualRects(intersection, NSMakeRect(0, 0, 0, 0)), @"Weighted Intersection should work");
   intersection = [MathUtils weightedIntersectionOf:a and:b weight:2];
-  STAssertTrue(NSEqualRects(intersection, NSMakeRect(0, 0, 0, 0)), @"Weighted Intersection should work");
+  XCTAssertTrue(NSEqualRects(intersection, NSMakeRect(0, 0, 0, 0)), @"Weighted Intersection should work");
   intersection = [MathUtils weightedIntersectionOf:a and:b weight:0.5];
-  STAssertTrue(NSEqualRects(intersection, NSMakeRect(0, 0, 0, 0)), @"Weighted Intersection should work");
+  XCTAssertTrue(NSEqualRects(intersection, NSMakeRect(0, 0, 0, 0)), @"Weighted Intersection should work");
   intersection = [MathUtils weightedIntersectionOf:a and:c weight:1];
-  STAssertTrue(NSEqualRects(intersection, NSMakeRect(0, 0, 50, 50)), @"Weighted Intersection should work");
+  XCTAssertTrue(NSEqualRects(intersection, NSMakeRect(0, 0, 50, 50)), @"Weighted Intersection should work");
   intersection = [MathUtils weightedIntersectionOf:a and:c weight:2];
-  STAssertTrue(NSEqualRects(intersection, NSMakeRect(0, 0, 100, 100)), @"Weighted Intersection should work");
+  XCTAssertTrue(NSEqualRects(intersection, NSMakeRect(0, 0, 100, 100)), @"Weighted Intersection should work");
   intersection = [MathUtils weightedIntersectionOf:a and:c weight:0.5];
-  STAssertTrue(NSEqualRects(intersection, NSMakeRect(0, 0, 25, 25)), @"Weighted Intersection should work");
+  XCTAssertTrue(NSEqualRects(intersection, NSMakeRect(0, 0, 25, 25)), @"Weighted Intersection should work");
   intersection = [MathUtils weightedIntersectionOf:a and:d weight:1];
-  STAssertTrue(NSEqualRects(intersection, NSMakeRect(50, 50, 50, 50)), @"Weighted Intersection should work");
+  XCTAssertTrue(NSEqualRects(intersection, NSMakeRect(50, 50, 50, 50)), @"Weighted Intersection should work");
   intersection = [MathUtils weightedIntersectionOf:a and:d weight:2];
-  STAssertTrue(NSEqualRects(intersection, NSMakeRect(50, 50, 100, 100)), @"Weighted Intersection should work");
+  XCTAssertTrue(NSEqualRects(intersection, NSMakeRect(50, 50, 100, 100)), @"Weighted Intersection should work");
   intersection = [MathUtils weightedIntersectionOf:a and:d weight:0.5];
-  STAssertTrue(NSEqualRects(intersection, NSMakeRect(50, 50, 25, 25)), @"Weighted Intersection should work");
+  XCTAssertTrue(NSEqualRects(intersection, NSMakeRect(50, 50, 25, 25)), @"Weighted Intersection should work");
 }
 
 @end

--- a/SlateTests/TestNSString+Indicies.h
+++ b/SlateTests/TestNSString+Indicies.h
@@ -18,8 +18,8 @@
 //  You should have received a copy of the GNU General Public License
 //  along with this program.  If not, see http://www.gnu.org/licenses
 
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 
-@interface TestNSString_Indicies : SenTestCase
+@interface TestNSString_Indicies : XCTestCase
 
 @end

--- a/SlateTests/TestNSString+Indicies.m
+++ b/SlateTests/TestNSString+Indicies.m
@@ -25,18 +25,18 @@
 
 - (void)testIndexOfString {
   NSString *test = @"hello&i%am-a$test#string";
-  STAssertEquals([test indexOfString:@"&"], (NSInteger)5, @"index of & should be 5");
-  STAssertEquals([test indexOfString:@"0"], (NSInteger)-1, @"index of 0 should be -1");
-  STAssertEquals([test indexOfString:@"hello"], (NSInteger)0, @"index of hello should be 0");
-  STAssertEquals([test indexOfString:@"g"], (NSInteger)([test length]-1), @"index of 0 should be ld", [test length]-1);
+  XCTAssertEqual([test indexOfString:@"&"], (NSInteger)5, @"index of & should be 5");
+  XCTAssertEqual([test indexOfString:@"0"], (NSInteger)-1, @"index of 0 should be -1");
+  XCTAssertEqual([test indexOfString:@"hello"], (NSInteger)0, @"index of hello should be 0");
+  XCTAssertEqual([test indexOfString:@"g"], (NSInteger)([test length]-1), @"index of 0 should be ld", [test length]-1);
 }
 
 - (void)testIndexOfChar {
   NSString *test = @"hello&i%am-a$test#string";
-  STAssertEquals([test indexOfChar:'&'], (NSInteger)5, @"index of & should be 5");
-  STAssertEquals([test indexOfChar:'0'], (NSInteger)-1, @"index of 0 should be -1");
-  STAssertEquals([test indexOfChar:'h'], (NSInteger)0, @"index of h should be 0");
-  STAssertEquals([test indexOfChar:'g'], (NSInteger)([test length]-1), @"index of g should be %ld", [test length]-1);
+  XCTAssertEqual([test indexOfChar:'&'], (NSInteger)5, @"index of & should be 5");
+  XCTAssertEqual([test indexOfChar:'0'], (NSInteger)-1, @"index of 0 should be -1");
+  XCTAssertEqual([test indexOfChar:'h'], (NSInteger)0, @"index of h should be 0");
+  XCTAssertEqual([test indexOfChar:'g'], (NSInteger)([test length]-1), @"index of g should be %ld", [test length]-1);
 }
 
 @end

--- a/SlateTests/TestNSString+Levenshtein.h
+++ b/SlateTests/TestNSString+Levenshtein.h
@@ -18,8 +18,8 @@
 //  You should have received a copy of the GNU General Public License
 //  along with this program.  If not, see http://www.gnu.org/licenses
 
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 
-@interface TestNSString_Levenshtein : SenTestCase
+@interface TestNSString_Levenshtein : XCTestCase
 
 @end

--- a/SlateTests/TestNSString+Levenshtein.m
+++ b/SlateTests/TestNSString+Levenshtein.m
@@ -29,10 +29,10 @@
   NSString *c = @"hallo";
   NSString *d = @"helllo";
   NSString *e = @"hldla";
-  STAssertEquals([a levenshteinDistance:b], (float)1, @"Levenshtein Distance between hello and helo should be 1");
-  STAssertEquals([a levenshteinDistance:c], (float)1, @"Levenshtein Distance between hello and hallo should be 1");
-  STAssertEquals([a levenshteinDistance:d], (float)1, @"Levenshtein Distance between hello and helllo should be 1");
-  STAssertEquals([a levenshteinDistance:e], (float)3, @"Levenshtein Distance between hello and hldlo should be 3");
+  XCTAssertEqual([a levenshteinDistance:b], (float)1, @"Levenshtein Distance between hello and helo should be 1");
+  XCTAssertEqual([a levenshteinDistance:c], (float)1, @"Levenshtein Distance between hello and hallo should be 1");
+  XCTAssertEqual([a levenshteinDistance:d], (float)1, @"Levenshtein Distance between hello and helllo should be 1");
+  XCTAssertEqual([a levenshteinDistance:e], (float)3, @"Levenshtein Distance between hello and hldlo should be 3");
 }
 
 - (void)testSequentialDistance {
@@ -42,11 +42,11 @@
   NSString *d = @"ello";
   NSString *e = @"helllo";
   NSString *f = @"heldlo";
-  STAssertEquals([a sequentialDistance:b], (float)4, @"Sequential Distance between hello and hell should be 4");
-  STAssertEquals([a sequentialDistance:c], (float)1, @"Sequential Distance between hello and hallo should be 1");
-  STAssertEquals([a sequentialDistance:d], (float)0, @"Sequential Distance between hello and hallo should be 0");
-  STAssertEquals([a sequentialDistance:e], (float)4, @"Sequential Distance between hello and ello should be 4");
-  STAssertEquals([a sequentialDistance:f], (float)3, @"Sequential Distance between hello and heldlo should be 3");
+  XCTAssertEqual([a sequentialDistance:b], (float)4, @"Sequential Distance between hello and hell should be 4");
+  XCTAssertEqual([a sequentialDistance:c], (float)1, @"Sequential Distance between hello and hallo should be 1");
+  XCTAssertEqual([a sequentialDistance:d], (float)0, @"Sequential Distance between hello and hallo should be 0");
+  XCTAssertEqual([a sequentialDistance:e], (float)4, @"Sequential Distance between hello and ello should be 4");
+  XCTAssertEqual([a sequentialDistance:f], (float)3, @"Sequential Distance between hello and heldlo should be 3");
 }
 
 @end

--- a/SlateTests/TestShellUtils.h
+++ b/SlateTests/TestShellUtils.h
@@ -18,8 +18,8 @@
 //  You should have received a copy of the GNU General Public License
 //  along with this program.  If not, see http://www.gnu.org/licenses
 
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 
-@interface TestShellUtils : SenTestCase
+@interface TestShellUtils : XCTestCase
 
 @end

--- a/SlateTests/TestShellUtils.m
+++ b/SlateTests/TestShellUtils.m
@@ -20,29 +20,30 @@
 
 #import "TestShellUtils.h"
 #import "ShellUtils.h"
+#import "ShellOperation.h"
 
 @implementation TestShellUtils
 
 - (void)testCommandExists {
-  STAssertTrue([ShellUtils commandExists:@"command"], @"command should exist");
-  STAssertTrue([ShellUtils commandExists:@"/usr/bin/command"], @"/usr/bin/command should exist");
-  STAssertFalse([ShellUtils commandExists:@"/usr/command"], @"/usr/command should not exist");
-  STAssertFalse([ShellUtils commandExists:@"oogabooga"], @"oogabooga should not exist");
-  STAssertFalse([ShellUtils commandExists:nil], @"nil should not exist");
-  STAssertFalse([ShellUtils commandExists:@""], @"empty string should not exist");
+  XCTAssertTrue([ShellUtils commandExists:@"command"], @"command should exist");
+  XCTAssertTrue([ShellUtils commandExists:@"/usr/bin/command"], @"/usr/bin/command should exist");
+  XCTAssertFalse([ShellUtils commandExists:@"/usr/command"], @"/usr/command should not exist");
+  XCTAssertFalse([ShellUtils commandExists:@"oogabooga"], @"oogabooga should not exist");
+  XCTAssertFalse([ShellUtils commandExists:nil], @"nil should not exist");
+  XCTAssertFalse([ShellUtils commandExists:@""], @"empty string should not exist");
 }
 
 - (void)testRun {
   NSTask *task = [ShellUtils run:@"/bin/ls" args:[NSArray arrayWithObject:@"-al"] wait:YES path:nil];
-  STAssertFalse([task isRunning], @"Task should no longer be running");
-  STAssertEquals([task terminationStatus], 0, @"Status should be 0");
+  XCTAssertFalse([task isRunning], @"Task should no longer be running");
+  XCTAssertEqual([task terminationStatus], 0, @"Status should be 0");
   task = [ShellUtils run:@"/usr/bin/find" args:[NSArray arrayWithObjects:@"/", @"-name", @"\"hello\"", nil] wait:NO path:@"/usr"];
-  STAssertTrue([task isRunning], @"Task should still be running");
-  STAssertTrue([[task currentDirectoryPath] isEqualToString:@"/usr"], @"current path should be /usr");
+  XCTAssertTrue([task isRunning], @"Task should still be running");
+  XCTAssertTrue([[task currentDirectoryPath] isEqualToString:@"/usr"], @"current path should be /usr");
   [task terminate];
   [task waitUntilExit];
-  STAssertFalse([task isRunning], @"Task should no longer be running");
-  STAssertEquals([task terminationStatus], 15, @"Status should be 15");
+  XCTAssertFalse([task isRunning], @"Task should no longer be running");
+  XCTAssertEqual([task terminationStatus], 15, @"Status should be 15");
 }
 
 - (void)testRunWithQuotedArgs {
@@ -50,7 +51,14 @@
   NSError *err = nil;
   NSRegularExpression *testRegex = [NSRegularExpression regularExpressionWithPattern:@"with single and double quotes" options:0 error:&err];
   int found = [testRegex numberOfMatchesInString:result options:0 range:NSMakeRange(0, [result length])];
-  STAssertEquals(found, 1, @"Result should include all strings");
+  XCTAssertEqual(found, 1, @"Result should include all strings");
+}
+
+- (void)testShellOperationFromStringWithQuotesAndSpaces {
+	id operation = [ShellOperation shellOperationFromString:@"shell '/usr/bin/open -a \"/Applications/App Store.app\"'"];
+	NSUInteger argumentCount = [[operation args] count];
+	
+	XCTAssertEqual(argumentCount, 2, @"The shell operation must only contain two arguments");
 }
 
 @end

--- a/SlateTests/TestStringTokenizer.h
+++ b/SlateTests/TestStringTokenizer.h
@@ -18,8 +18,8 @@
 //  You should have received a copy of the GNU General Public License
 //  along with this program.  If not, see http://www.gnu.org/licenses
 
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 
-@interface TestStringTokenizer : SenTestCase
+@interface TestStringTokenizer : XCTestCase
 
 @end

--- a/SlateTests/TestStringTokenizer.m
+++ b/SlateTests/TestStringTokenizer.m
@@ -32,113 +32,113 @@
 */
 
 - (void)testIsSpaceChar {
-  STAssertTrue([StringTokenizer isSpaceChar:' '], @"work.");
-  STAssertTrue([StringTokenizer isSpaceChar:'\t'], @"work.");
+  XCTAssertTrue([StringTokenizer isSpaceChar:' '], @"work.");
+  XCTAssertTrue([StringTokenizer isSpaceChar:'\t'], @"work.");
 }
 
 - (void)testIsQuoteChar {
   NSCharacterSet *cs = [NSCharacterSet characterSetWithCharactersInString:@""];
-  STAssertFalse([StringTokenizer isQuoteChar:'"' quoteChars:cs], @"stuff");
+  XCTAssertFalse([StringTokenizer isQuoteChar:'"' quoteChars:cs], @"stuff");
   cs = [NSCharacterSet characterSetWithCharactersInString:@"\""];
-  STAssertTrue([StringTokenizer isQuoteChar:'"' quoteChars:cs], @"stuff");
+  XCTAssertTrue([StringTokenizer isQuoteChar:'"' quoteChars:cs], @"stuff");
   cs = [NSCharacterSet characterSetWithCharactersInString:@"'"];
-  STAssertFalse([StringTokenizer isQuoteChar:'"' quoteChars:cs], @"stuff");
+  XCTAssertFalse([StringTokenizer isQuoteChar:'"' quoteChars:cs], @"stuff");
   cs = [NSCharacterSet characterSetWithCharactersInString:@"\"'"];
-  STAssertTrue([StringTokenizer isQuoteChar:'"' quoteChars:cs], @"stuff");
+  XCTAssertTrue([StringTokenizer isQuoteChar:'"' quoteChars:cs], @"stuff");
   cs = [NSCharacterSet characterSetWithCharactersInString:@"\"'"];
-  STAssertTrue([StringTokenizer isQuoteChar:'\'' quoteChars:cs], @"stuff");
+  XCTAssertTrue([StringTokenizer isQuoteChar:'\'' quoteChars:cs], @"stuff");
 }
 
 - (void)testTokenizeInto {
   NSMutableArray *arr = [NSMutableArray array];
   [StringTokenizer tokenize:@"hi tokenize\t\t  me" into:arr];
-  STAssertTrue([arr count] == 3, @"shit should work");
-  STAssertTrue([[arr objectAtIndex:0] isEqualToString:@"hi"], @"work damnit");
-  STAssertTrue([[arr objectAtIndex:1] isEqualToString:@"tokenize"], @"wtf");
-  STAssertTrue([[arr objectAtIndex:2] isEqualToString:@"me"], @"OMGWTFBBQ");
+  XCTAssertTrue([arr count] == 3, @"shit should work");
+  XCTAssertTrue([[arr objectAtIndex:0] isEqualToString:@"hi"], @"work damnit");
+  XCTAssertTrue([[arr objectAtIndex:1] isEqualToString:@"tokenize"], @"wtf");
+  XCTAssertTrue([[arr objectAtIndex:2] isEqualToString:@"me"], @"OMGWTFBBQ");
   arr = [NSMutableArray array];
   [StringTokenizer tokenize:@"hitokenizeme" into:arr];
-  STAssertTrue([arr count] == 1, @"shit should work");
-  STAssertTrue([[arr objectAtIndex:0] isEqualToString:@"hitokenizeme"], @"work damnit");
+  XCTAssertTrue([arr count] == 1, @"shit should work");
+  XCTAssertTrue([[arr objectAtIndex:0] isEqualToString:@"hitokenizeme"], @"work damnit");
   arr = [NSMutableArray array];
   [StringTokenizer tokenize:@"" into:arr];
-  STAssertTrue([arr count] == 0, @"shit should work");
+  XCTAssertTrue([arr count] == 0, @"shit should work");
 }
 
 - (void)testTokenizeIntoQuoteChars {
   NSMutableArray *arr = [NSMutableArray array];
   NSCharacterSet *cs = [NSCharacterSet characterSetWithCharactersInString:@"\"'"];
   [StringTokenizer tokenize:@"hi tokenize\t\t  me" into:arr quoteChars:cs];
-  STAssertTrue([arr count] == 3, @"shit should work");
-  STAssertTrue([[arr objectAtIndex:0] isEqualToString:@"hi"], @"work damnit");
-  STAssertTrue([[arr objectAtIndex:1] isEqualToString:@"tokenize"], @"wtf");
-  STAssertTrue([[arr objectAtIndex:2] isEqualToString:@"me"], @"OMGWTFBBQ");
+  XCTAssertTrue([arr count] == 3, @"shit should work");
+  XCTAssertTrue([[arr objectAtIndex:0] isEqualToString:@"hi"], @"work damnit");
+  XCTAssertTrue([[arr objectAtIndex:1] isEqualToString:@"tokenize"], @"wtf");
+  XCTAssertTrue([[arr objectAtIndex:2] isEqualToString:@"me"], @"OMGWTFBBQ");
   arr = [NSMutableArray array];
   [StringTokenizer tokenize:@"" into:arr quoteChars:cs];
-  STAssertTrue([arr count] == 0, @"shit should work");
+  XCTAssertTrue([arr count] == 0, @"shit should work");
   arr = [NSMutableArray array];
   [StringTokenizer tokenize:@"hi 'tokenize\t\t  me'" into:arr maxTokens:100 quoteChars:cs];
-  STAssertTrue([arr count] == 2, @"shit should work");
-  STAssertTrue([[arr objectAtIndex:0] isEqualToString:@"hi"], @"work damnit");
-  STAssertTrue([[arr objectAtIndex:1] isEqualToString:@"tokenize\t\t  me"], @"wtf");
+  XCTAssertTrue([arr count] == 2, @"shit should work");
+  XCTAssertTrue([[arr objectAtIndex:0] isEqualToString:@"hi"], @"work damnit");
+  XCTAssertTrue([[arr objectAtIndex:1] isEqualToString:@"tokenize\t\t  me"], @"wtf");
 }
 
 - (void)testTokenizeIntoMaxTokens {
   NSMutableArray *arr = [NSMutableArray array];
   [StringTokenizer tokenize:@"hi tokenize\t\t  me" into:arr maxTokens:100];
-  STAssertTrue([arr count] == 3, @"shit should work");
-  STAssertTrue([[arr objectAtIndex:0] isEqualToString:@"hi"], @"work damnit");
-  STAssertTrue([[arr objectAtIndex:1] isEqualToString:@"tokenize"], @"wtf");
-  STAssertTrue([[arr objectAtIndex:2] isEqualToString:@"me"], @"OMGWTFBBQ");
+  XCTAssertTrue([arr count] == 3, @"shit should work");
+  XCTAssertTrue([[arr objectAtIndex:0] isEqualToString:@"hi"], @"work damnit");
+  XCTAssertTrue([[arr objectAtIndex:1] isEqualToString:@"tokenize"], @"wtf");
+  XCTAssertTrue([[arr objectAtIndex:2] isEqualToString:@"me"], @"OMGWTFBBQ");
   arr = [NSMutableArray array];
   [StringTokenizer tokenize:@"hi tokenize\t\t  me" into:arr maxTokens:2];
-  STAssertTrue([arr count] == 2, @"shit should work");
-  STAssertTrue([[arr objectAtIndex:0] isEqualToString:@"hi"], @"work damnit");
-  STAssertTrue([[arr objectAtIndex:1] isEqualToString:@"tokenize\t\t  me"], @"wtf");
+  XCTAssertTrue([arr count] == 2, @"shit should work");
+  XCTAssertTrue([[arr objectAtIndex:0] isEqualToString:@"hi"], @"work damnit");
+  XCTAssertTrue([[arr objectAtIndex:1] isEqualToString:@"tokenize\t\t  me"], @"wtf");
   arr = [NSMutableArray array];
   [StringTokenizer tokenize:@"hi tokenize me" into:arr maxTokens:1];
-  STAssertTrue([arr count] == 1, @"shit should work");
-  STAssertTrue([[arr objectAtIndex:0] isEqualToString:@"hi tokenize me"], @"work damnit");
+  XCTAssertTrue([arr count] == 1, @"shit should work");
+  XCTAssertTrue([[arr objectAtIndex:0] isEqualToString:@"hi tokenize me"], @"work damnit");
   arr = [NSMutableArray array];
   [StringTokenizer tokenize:@"" into:arr maxTokens:1000];
-  STAssertTrue([arr count] == 0, @"shit should work");
+  XCTAssertTrue([arr count] == 0, @"shit should work");
 }
 
 - (void)testTokenizeIntoMaxTokensQuoteChars {
   NSMutableArray *arr = [NSMutableArray array];
   NSCharacterSet *cs = [NSCharacterSet characterSetWithCharactersInString:@"\"'"];
   [StringTokenizer tokenize:@"hi tokenize\t\t  me" into:arr maxTokens:100 quoteChars:cs];
-  STAssertTrue([arr count] == 3, @"shit should work");
-  STAssertTrue([[arr objectAtIndex:0] isEqualToString:@"hi"], @"work damnit");
-  STAssertTrue([[arr objectAtIndex:1] isEqualToString:@"tokenize"], @"wtf");
-  STAssertTrue([[arr objectAtIndex:2] isEqualToString:@"me"], @"OMGWTFBBQ");
+  XCTAssertTrue([arr count] == 3, @"shit should work");
+  XCTAssertTrue([[arr objectAtIndex:0] isEqualToString:@"hi"], @"work damnit");
+  XCTAssertTrue([[arr objectAtIndex:1] isEqualToString:@"tokenize"], @"wtf");
+  XCTAssertTrue([[arr objectAtIndex:2] isEqualToString:@"me"], @"OMGWTFBBQ");
   arr = [NSMutableArray array];
   [StringTokenizer tokenize:@"hi tokenize\t\t  me" into:arr maxTokens:2 quoteChars:cs];
-  STAssertTrue([arr count] == 2, @"shit should work");
-  STAssertTrue([[arr objectAtIndex:0] isEqualToString:@"hi"], @"work damnit");
-  STAssertTrue([[arr objectAtIndex:1] isEqualToString:@"tokenize\t\t  me"], @"wtf");
+  XCTAssertTrue([arr count] == 2, @"shit should work");
+  XCTAssertTrue([[arr objectAtIndex:0] isEqualToString:@"hi"], @"work damnit");
+  XCTAssertTrue([[arr objectAtIndex:1] isEqualToString:@"tokenize\t\t  me"], @"wtf");
   arr = [NSMutableArray array];
   [StringTokenizer tokenize:@"hi tokenize me" into:arr maxTokens:1 quoteChars:cs];
-  STAssertTrue([arr count] == 1, @"shit should work");
-  STAssertTrue([[arr objectAtIndex:0] isEqualToString:@"hi tokenize me"], @"work damnit");
+  XCTAssertTrue([arr count] == 1, @"shit should work");
+  XCTAssertTrue([[arr objectAtIndex:0] isEqualToString:@"hi tokenize me"], @"work damnit");
   arr = [NSMutableArray array];
   [StringTokenizer tokenize:@"" into:arr maxTokens:1000 quoteChars:cs];
-  STAssertTrue([arr count] == 0, @"shit should work");
+  XCTAssertTrue([arr count] == 0, @"shit should work");
   arr = [NSMutableArray array];
   [StringTokenizer tokenize:@"hi 'tokenize\t\t  me'" into:arr maxTokens:100 quoteChars:cs];
-  STAssertTrue([arr count] == 2, @"shit should work");
-  STAssertTrue([[arr objectAtIndex:0] isEqualToString:@"hi"], @"work damnit");
-  STAssertTrue([[arr objectAtIndex:1] isEqualToString:@"tokenize\t\t  me"], @"wtf");
+  XCTAssertTrue([arr count] == 2, @"shit should work");
+  XCTAssertTrue([[arr objectAtIndex:0] isEqualToString:@"hi"], @"work damnit");
+  XCTAssertTrue([[arr objectAtIndex:1] isEqualToString:@"tokenize\t\t  me"], @"wtf");
   arr = [NSMutableArray array];
   [StringTokenizer tokenize:@"hi 'tokenize\t\t  \"me\"'" into:arr maxTokens:100 quoteChars:cs];
-  STAssertTrue([arr count] == 2, @"shit should work");
-  STAssertTrue([[arr objectAtIndex:0] isEqualToString:@"hi"], @"work damnit");
-  STAssertTrue([[arr objectAtIndex:1] isEqualToString:@"tokenize\t\t  \"me\""], @"wtf");
+  XCTAssertTrue([arr count] == 2, @"shit should work");
+  XCTAssertTrue([[arr objectAtIndex:0] isEqualToString:@"hi"], @"work damnit");
+  XCTAssertTrue([[arr objectAtIndex:1] isEqualToString:@"tokenize\t\t  \"me\""], @"wtf");
   arr = [NSMutableArray array];
   [StringTokenizer tokenize:@"hi 'tokenize\t\t  \"me\"'" into:arr quoteChars:cs];
-  STAssertTrue([arr count] == 2, @"shit should work");
-  STAssertTrue([[arr objectAtIndex:0] isEqualToString:@"hi"], @"work damnit");
-  STAssertTrue([[arr objectAtIndex:1] isEqualToString:@"tokenize\t\t  \"me\""], @"wtf");
+  XCTAssertTrue([arr count] == 2, @"shit should work");
+  XCTAssertTrue([[arr objectAtIndex:0] isEqualToString:@"hi"], @"work damnit");
+  XCTAssertTrue([[arr objectAtIndex:1] isEqualToString:@"tokenize\t\t  \"me\""], @"wtf");
 }
 
 @end


### PR DESCRIPTION
This is a fix so that Slate is able to run shell commands for applications whose names have spaces in them.

This, for example, would not work until this fix: shell '/usr/bin/open -a "/Applications/Sublime Text.app"'

Note: simply surround the argument, in this case "/Applications/Sublime Text.app" with double-quotes.
